### PR TITLE
Fix SPIR-V debug info for opaque types

### DIFF
--- a/source/slang/slang-emit-spirv-ops-debug-info-ext.h
+++ b/source/slang/slang-emit-spirv-ops-debug-info-ext.h
@@ -1,5 +1,17 @@
 #ifdef SLANG_IN_SPIRV_EMIT_CONTEXT
 
+// https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.asciidoc#DebugInfoNone
+template<typename T>
+SpvInst* emitOpDebugInfoNone(
+    SpvInstParent* parent,
+    IRInst* inst,
+    const T& idResultType,
+    SpvInst* set)
+{
+    static_assert(isSingular<T>);
+    return emitInst(parent, inst, SpvOpExtInst, idResultType, kResultID, set, SpvWord(0));
+}
+
 // https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.asciidoc#DebugCompilationUnit
 template<typename T>
 SpvInst* emitOpDebugCompilationUnit(
@@ -222,7 +234,7 @@ SpvInst* emitOpDebugTypeComposite(
     IRInst* col,
     SpvInst* scope,
     IRInst* linkageName,
-    IRInst* size,
+    SpvInst* size,
     IRInst* flags,
     const Ts& members)
 {

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -1544,6 +1544,20 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         return m_NonSemanticDebugInfoExtInst;
     }
 
+    SpvInst* m_debugInfoNone = nullptr;
+
+    SpvInst* getDebugInfoNone()
+    {
+        if (m_debugInfoNone)
+            return m_debugInfoNone;
+        m_debugInfoNone = emitOpDebugInfoNone(
+            getSection(SpvLogicalSectionID::ConstantsAndTypes),
+            nullptr,
+            m_voidType,
+            getNonSemanticDebugInfoExtInst());
+        return m_debugInfoNone;
+    }
+
     /// The SPIRV OpExtInstImport inst that represents the NonSemantic debug info
     /// extended instruction set.
     SpvInst* m_NonSemanticDebugPrintfExtInst = nullptr;
@@ -10912,9 +10926,9 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         }
     }
 
-    IRInst* getName(IRInst* inst)
+    IRStringLit* getName(IRInst* inst)
     {
-        IRInst* nameOperand = nullptr;
+        IRStringLit* nameOperand = nullptr;
         for (auto decor : inst->getDecorations())
         {
             if (auto nameHint = as<IRNameHintDecoration>(decor))
@@ -11128,7 +11142,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 col,
                 scope,
                 name,
-                builder.getIntValue(builder.getUIntType(), structSizeAlignment.size * 8),
+                ensureInst(
+                    builder.getIntValue(builder.getUIntType(), structSizeAlignment.size * 8)),
                 builder.getIntValue(builder.getUIntType(), kUnknownPhysicalLayout),
                 members);
         }
@@ -11291,6 +11306,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         IRInst* source = m_defaultDebugSource;
         IRInst* line = builder.getIntValue(builder.getUIntType(), 0);
         IRInst* col = line;
+        auto linkageName = builder.getStringValue(
+            (StringBuilder() << "@" << name->getStringSlice()).getUnownedSlice());
 
         // Emit a composite debug type (struct-like for most types)
         return emitOpDebugTypeComposite(
@@ -11304,8 +11321,8 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             line,
             col,
             scope,
-            name,
-            builder.getIntValue(builder.getUIntType(), 0), // Size (unknown)
+            linkageName,
+            getDebugInfoNone(),
             builder.getIntValue(builder.getUIntType(), kUnknownPhysicalLayout),
             List<SpvInst*>()); // No members
     }

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -3268,6 +3268,7 @@ static SlangResult stripDbgSpirvFromArtifact(
     // to check if the instruction number is for a debug instruction as
     // listed in slang-emit-spirv-ops-debug-info-ext.h
     static const uint32_t debugExtInstVals[] = {
+        NonSemanticShaderDebugInfo100DebugInfoNone,
         NonSemanticShaderDebugInfo100DebugCompilationUnit,
         NonSemanticShaderDebugInfo100DebugTypeBasic,
         NonSemanticShaderDebugInfo100DebugTypePointer,

--- a/tests/spirv/debug-info-opaque-types.slang
+++ b/tests/spirv/debug-info-opaque-types.slang
@@ -1,0 +1,38 @@
+//TEST:SIMPLE(filecheck=CHECK):-target spirv -entry main -stage fragment -g2 -emit-spirv-directly
+//TEST:SIMPLE(filecheck=SEPARATE):-target spirv -entry main -stage fragment -g2 -emit-spirv-directly -separate-debug-info -separate-debug-info-output debug-info-opaque-types.dbg.spv
+
+Texture2D texture;
+SamplerState sampler;
+
+struct Empty
+{}
+
+// Keep the empty struct in the emitted debug information so it can serve as a non-opaque control.
+[noinline]
+float4 preserveEmptyType(Empty value, float4 result)
+{
+    return result;
+}
+
+[shader("fragment")]
+float4 main(float2 uv : TEXCOORD0) : SV_Target
+{
+    Empty ordinary;
+    return preserveEmptyType(ordinary, texture.Sample(sampler, uv));
+}
+
+// CHECK-DAG: %[[DEBUG_INFO_NONE:[0-9]+]] = OpExtInst %void %{{[0-9]+}} DebugInfoNone
+// CHECK-DAG: %[[TEXTURE_NAME:[0-9]+]] = OpString "Texture2D"
+// CHECK-DAG: %[[TEXTURE_LINKAGE_NAME:[0-9]+]] = OpString "@Texture2D"
+// CHECK-DAG: %{{[0-9]+}} = OpExtInst %void %{{[0-9]+}} DebugTypeComposite %[[TEXTURE_NAME]] %uint_0 %{{[0-9]+}} %uint_0 %uint_0 %{{[0-9]+}} %[[TEXTURE_LINKAGE_NAME]] %[[DEBUG_INFO_NONE]] %uint_131072{{$}}
+// CHECK-DAG: %[[SAMPLER_NAME:[0-9]+]] = OpString "SamplerState"
+// CHECK-DAG: %[[SAMPLER_LINKAGE_NAME:[0-9]+]] = OpString "@SamplerState"
+// CHECK-DAG: %{{[0-9]+}} = OpExtInst %void %{{[0-9]+}} DebugTypeComposite %[[SAMPLER_NAME]] %uint_0 %{{[0-9]+}} %uint_0 %uint_0 %{{[0-9]+}} %[[SAMPLER_LINKAGE_NAME]] %[[DEBUG_INFO_NONE]] %uint_131072{{$}}
+// CHECK-DAG: %[[EMPTY_NAME:[0-9]+]] = OpString "Empty"
+// CHECK-DAG: %{{[0-9]+}} = OpExtInst %void %{{[0-9]+}} DebugTypeComposite %[[EMPTY_NAME]] %uint_1 %{{[a-zA-Z0-9_]+}} %{{[a-zA-Z0-9_]+}} %{{[a-zA-Z0-9_]+}} %{{[a-zA-Z0-9_]+}} %[[EMPTY_NAME]] %uint_0 %uint_131072{{$}}
+
+// SEPARATE-NOT: DebugInfoNone
+// SEPARATE-NOT: DebugTypeComposite
+// SEPARATE: DebugBuildIdentifier
+// SEPARATE-NOT: DebugInfoNone
+// SEPARATE-NOT: DebugTypeComposite

--- a/tests/spirv/debug-info-rtas.slang
+++ b/tests/spirv/debug-info-rtas.slang
@@ -29,6 +29,8 @@ void main()
              payload);
 }
 
-// CHECK: %[[TYPENAME:[0-9]+]] = OpString "RaytracingAccelerationStructure"
-// CHECK: %[[TYPE:[0-9]+]] = OpExtInst %void %{{[a-zA-Z0-9_]+}} DebugTypeComposite %[[TYPENAME]]
+// CHECK-DAG: %[[DEBUG_INFO_NONE:[0-9]+]] = OpExtInst %void %{{[0-9]+}} DebugInfoNone
+// CHECK-DAG: %[[TYPENAME:[0-9]+]] = OpString "RaytracingAccelerationStructure"
+// CHECK-DAG: %[[LINKAGE_NAME:[0-9]+]] = OpString "@RaytracingAccelerationStructure"
+// CHECK-DAG: %[[TYPE:[0-9]+]] = OpExtInst %void %{{[0-9]+}} DebugTypeComposite %[[TYPENAME]] %uint_0 %{{[0-9]+}} %uint_0 %uint_0 %{{[0-9]+}} %[[LINKAGE_NAME]] %[[DEBUG_INFO_NONE]] %uint_131072{{$}}
 // CHECK: OpExtInst %void %{{[0-9]+}} DebugGlobalVariable %{{[0-9]+}} %[[TYPE]] %{{.*}} %rtas


### PR DESCRIPTION
Opaque resource types do not have a meaningful physical size, but their synthetic DebugTypeComposite records previously used zero. Zero is a real size and is also the correct encoding for an empty ordinary struct.

Emit a cached DebugInfoNone and use its result ID as the Size operand for opaque composites, while continuing to emit numeric size IDs for ordinary structs. Also provide readable names and linkage names, and teach separate-debug-info stripping to recognize the new instruction.

Cover textures, samplers, ray-tracing acceleration structures, an empty ordinary struct, and separate debug-info output.

Fixes #12807