### PR TITLE
Canonicalize SPIR-V matrix debug types

### DIFF
--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -4679,7 +4679,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
         auto name = getName(debugVar);
         auto varType = tryGetPointedToType(&builder, debugVar->getDataType());
-        auto debugType = emitDebugType(varType, false);
+        auto debugType = emitDebugType(varType);
 
         auto spvDebugLocalVar = emitOpDebugLocalVariable(
             getSection(SpvLogicalSectionID::ConstantsAndTypes),
@@ -4781,7 +4781,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         auto name = getName(globalInst);
         IRBuilder builder(globalInst);
         auto varType = tryGetPointedToType(&builder, globalInst->getDataType());
-        auto debugType = emitDebugType(varType, false);
+        auto debugType = emitDebugType(varType);
 
         // Use default debug source and line info similar to struct debug type emission
         auto loc = globalInst->findDecoration<IRDebugLocationDecoration>();
@@ -10668,7 +10668,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         if (!scope)
             return nullptr;
 
-        SpvInst* neededDebugType = emitDebugType(as<IRFuncType>(debugFunc->getDebugType()), false);
+        SpvInst* neededDebugType = emitDebugType(as<IRFuncType>(debugFunc->getDebugType()));
         SLANG_ASSERT(neededDebugType);
 
         IRBuilder builder(debugFunc);
@@ -10946,19 +10946,14 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
     static constexpr const int kUnknownPhysicalLayout = 1 << 17;
     static constexpr const int kDebugTypeAtomicQualifier = 3;
 
-    // Normalize matrix layout for debug info emission.
-    // Matrix layout (row-major vs column-major) only affects memory accesses
-    // to buffers.
-    // For non-buffer contexts, matrices are always treated as row-major (in
-    // Slang terms).
-    IRType* normalizeMatrixDebugType(IRType* type, bool isTypeInBuffer)
+    // Normalize matrix types to Slang's row-major layout mode when emitting debug info, matching
+    // the DebugTypeMatrix shape emitted by DXC and glslang. This only selects the debug type and
+    // cache key; it does not transpose matrix values or change matrix accesses or storage
+    // decorations.
+    IRType* normalizeMatrixDebugType(IRType* type)
     {
-        if (isTypeInBuffer)
-            return type; // Keep layout for types in buffers
-
         if (auto matrixType = as<IRMatrixType>(type))
         {
-            // Normalize to row-major for types not in buffers
             if (getIntVal(matrixType->getLayout()) != kMatrixLayoutMode_RowMajor)
             {
                 IRBuilder builder(type);
@@ -10972,7 +10967,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         return type;
     }
 
-    SpvInst* emitDebugTypeImpl(IRType* type, bool isTypeInBuffer)
+    SpvInst* emitDebugTypeImpl(IRType* type)
     {
         auto scope = findDebugScope(type);
         if (!scope)
@@ -10984,13 +10979,13 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             SpvInst* returnType = ensureInst(m_voidType);
             if (!as<IRVoidType>(funcType->getResultType()))
             {
-                returnType = emitDebugType(funcType->getResultType(), isTypeInBuffer);
+                returnType = emitDebugType(funcType->getResultType());
             }
 
             List<SpvInst*> argTypes;
             for (UInt i = 0; i < funcType->getParamCount(); ++i)
             {
-                argTypes.add(emitDebugType(funcType->getParamType(i), isTypeInBuffer));
+                argTypes.add(emitDebugType(funcType->getParamType(i)));
             }
 
             return emitOpDebugTypeFunction(
@@ -11063,12 +11058,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
 
                 if (spvFieldType == nullptr)
                 {
-                    bool isFieldTypeInBuffer =
-                        structType->findDecorationImpl(kIROp_SPIRVBlockDecoration) != nullptr ||
-                        structType->findDecorationImpl(kIROp_SPIRVBufferBlockDecoration) !=
-                            nullptr ||
-                        structType->findDecorationImpl(kIROp_PhysicalTypeDecoration) != nullptr;
-                    spvFieldType = emitDebugType(fieldType, isFieldTypeInBuffer);
+                    spvFieldType = emitDebugType(fieldType);
                 }
 
                 // Check if the field key has a debug location decoration
@@ -11141,7 +11131,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                 nullptr,
                 m_voidType,
                 getNonSemanticDebugInfoExtInst(),
-                emitDebugType(arrayType->getElementType(), isTypeInBuffer),
+                emitDebugType(arrayType->getElementType()),
                 sizedArrayType ? builder.getIntValue(
                                      builder.getUIntType(),
                                      getArraySizeVal(sizedArrayType->getElementCount()))
@@ -11149,7 +11139,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         }
         else if (auto vectorType = as<IRVectorType>(type))
         {
-            auto elementType = emitDebugType(vectorType->getElementType(), isTypeInBuffer);
+            auto elementType = emitDebugType(vectorType->getElementType());
             return emitOpDebugTypeVector(
                 getSection(SpvLogicalSectionID::ConstantsAndTypes),
                 nullptr,
@@ -11162,35 +11152,17 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         }
         else if (auto matrixType = as<IRMatrixType>(type))
         {
-            IRInst* count = nullptr;
-            bool isSpvColMajor;
-            IRType* innerVectorType = nullptr;
-
-            // kMatrixLayoutMode_RowMajor maps to SpvDecorationColMajor (and vice versa)
-            if (getIntVal(matrixType->getLayout()) == kMatrixLayoutMode_ColumnMajor)
-            {
-                innerVectorType =
-                    builder.getVectorType(matrixType->getElementType(), matrixType->getRowCount());
-                isSpvColMajor = false;
-                count = matrixType->getColumnCount();
-            }
-            else
-            {
-                innerVectorType = builder.getVectorType(
-                    matrixType->getElementType(),
-                    matrixType->getColumnCount());
-                isSpvColMajor = true;
-                count = matrixType->getRowCount();
-            }
-            auto elementType = emitDebugType(innerVectorType, isTypeInBuffer);
+            auto innerVectorType =
+                builder.getVectorType(matrixType->getElementType(), matrixType->getColumnCount());
+            auto elementType = emitDebugType(innerVectorType);
             return emitOpDebugTypeMatrix(
                 getSection(SpvLogicalSectionID::ConstantsAndTypes),
                 nullptr,
                 m_voidType,
                 getNonSemanticDebugInfoExtInst(),
                 elementType,
-                builder.getIntValue(builder.getUIntType(), getIntVal(count)),
-                builder.getBoolValue(isSpvColMajor));
+                builder.getIntValue(builder.getUIntType(), getIntVal(matrixType->getRowCount())),
+                builder.getBoolValue(true));
         }
         else if (as<IRBasicType>(type) || as<IRPackedFloatType>(type))
         {
@@ -11258,7 +11230,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         {
             IRType* baseType = ptrType->getValueType();
             // Emit DebugTypePointer for pointer types.
-            SpvInst* debugBaseType = emitDebugType(baseType, isTypeInBuffer);
+            SpvInst* debugBaseType = emitDebugType(baseType);
             SpvStorageClass storageClass = SpvStorageClassFunction;
             if (ptrType->hasAddressSpace())
                 storageClass = addressSpaceToStorageClass(ptrType->getAddressSpace());
@@ -11275,7 +11247,7 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
         else if (auto atomicType = as<IRAtomicType>(type))
         {
             auto baseType = atomicType->getElementType();
-            auto debugBaseType = emitDebugType(baseType, isTypeInBuffer);
+            auto debugBaseType = emitDebugType(baseType);
 
             return emitOpDebugTypeQualifier(
                 getSection(SpvLogicalSectionID::ConstantsAndTypes),
@@ -11310,16 +11282,16 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
             List<SpvInst*>()); // No members
     }
 
-    SpvInst* emitDebugType(IRType* type, bool isTypeInBuffer)
+    SpvInst* emitDebugType(IRType* type)
     {
-        type = normalizeMatrixDebugType(type, isTypeInBuffer);
+        type = normalizeMatrixDebugType(type);
 
         if (auto debugType = m_mapTypeToDebugType.tryGetValue(type))
             return *debugType;
         bool isStruct = type->getOp() == kIROp_StructType;
         if (isStruct)
             m_emittingTypes.add(type);
-        auto result = emitDebugTypeImpl(type, isTypeInBuffer);
+        auto result = emitDebugTypeImpl(type);
         if (isStruct)
             m_emittingTypes.remove(type);
         m_mapTypeToDebugType[type] = result;

--- a/tests/spirv/debug-matrix-layout-non-buffer.slang
+++ b/tests/spirv/debug-matrix-layout-non-buffer.slang
@@ -1,5 +1,5 @@
-// Validate DebugTypeMatrix column major argument for local and function parameter and return value matrices.
-// Expect matrix layout to always be row-major as the layout modifier only applies to buffer types (ConstantBuffer/RWStructuredBuffer/etc).
+// Validate the DebugTypeMatrix Column Major operand for local, parameter, and return-value
+// matrices. Expect every debug type to use SPIR-V's column-vector form (Column Major = true).
 //
 //TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -g2 -matrix-layout-row-major
 //TEST:SIMPLE(filecheck=CHECK):-target spirv-asm -g2 -matrix-layout-column-major
@@ -53,6 +53,6 @@ void main()
 }
 
 
-// Check there is no debug info with the SPIR-V DebugTypeMatrix column-major operand false (meaning all matrices are row-major)
+// Check that every DebugTypeMatrix uses SPIR-V's column-vector form (Column Major = true).
 //CHECK-NOT: OpExtInst %void {{.*}} DebugTypeMatrix {{.*}} %false
 //CHECK: OpExtInst %void {{.*}} DebugTypeMatrix {{.*}} %true

--- a/tests/spirv/debug-matrix-layout.slang
+++ b/tests/spirv/debug-matrix-layout.slang
@@ -1,8 +1,10 @@
-// Validate DebugTypeMatrix column major argument for buffer and local matrices.
-// Expect matrix layout to affect buffer matrices, but not local matrices which are always row-major (ColMajor in SPIR-V).
+// Validate buffer storage decorations and matrix debug types for buffer and local matrices.
+// Expect explicit or command-line layout to affect buffer member decorations, while every
+// DebugTypeMatrix uses SPIR-V's column-vector form (Column Major = true).
 //
 //TEST:SIMPLE(filecheck=CHECK,CHECK_COL):-target spirv-asm -g2 -matrix-layout-column-major
 //TEST:SIMPLE(filecheck=CHECK,CHECK_ROW):-target spirv-asm -g2 -matrix-layout-row-major
+//TEST:SIMPLE(filecheck=CHECK_NO_ROW_VECTOR):-target spirv-asm -g2 -matrix-layout-column-major
 
 struct S
 {
@@ -38,40 +40,44 @@ void main()
 }
 
 
-// Check struct members have correct matrix layouts
+// Check struct members have correct matrix layouts.
 //CHECK_ROW-DAG: OpMemberDecorate {{.*}} 0 ColMajor
 //CHECK_COL-DAG: OpMemberDecorate {{.*}} 0 RowMajor
 //CHECK-DAG: OpMemberDecorate {{.*}} 1 RowMajor
 //CHECK-DAG: OpMemberDecorate {{.*}} 2 ColMajor
 
-// When checking we have the correct debug info, we verify by:
-// 1. Getting the ids of the column-major and row-major DebugTypeMatrix (DTM_COLMAJOR and DTM_ROWMAJOR)
-// 2. Getting the OpString id for the member/variable to check (STR_member/variable)
-// 3. Check the DebugTypeMember/DebugLocalVariable has the expected id of the member/variable and id of the column-major or row-major DebugTypeMatrix
-
-//CHECK-DAG: [[FALSE:%[a-zA-Z0-9_]+]] = OpConstantFalse %bool
+// A float3x2 SPIR-V matrix value is three vec2 columns. To verify the debug info:
+// 1. Capture that canonical DebugTypeMatrix ID.
+// 2. Capture each buffer member or local variable's OpString ID.
+// 3. Verify its DebugTypeMember or DebugLocalVariable refers to that canonical type.
+//CHECK-DAG: [[TWO:%[a-zA-Z0-9_]+]] = OpConstant %uint 2{{$}}
+//CHECK-DAG: [[THREE:%[a-zA-Z0-9_]+]] = OpConstant %uint 3{{$}}
 //CHECK-DAG: [[TRUE:%[a-zA-Z0-9_]+]] = OpConstantTrue %bool
-//CHECK-DAG: [[DTM_COLMAJOR:%[0-9]+]] = OpExtInst %void {{.*}} DebugTypeMatrix {{.*}} [[FALSE]]
-//CHECK-DAG: [[DTM_ROWMAJOR:%[0-9]+]] = OpExtInst %void {{.*}} DebugTypeMatrix {{.*}} [[TRUE]]
+//CHECK-DAG: [[VEC2:%[0-9]+]] = OpExtInst %void {{.*}} DebugTypeVector {{.*}} [[TWO]]
+//CHECK-DAG: [[DTM:%[0-9]+]] = OpExtInst %void {{.*}} DebugTypeMatrix [[VEC2]] [[THREE]] [[TRUE]]
 
-// Buffer fields (capture via member -> type -> ordering)
+// Buffer members all refer to the canonical matrix debug type.
 //CHECK-DAG: [[STR_M:%[0-9]+]] = OpString "m"
-//CHECK_COL-DAG: DebugTypeMember [[STR_M]] [[DTM_COLMAJOR]]
-//CHECK_ROW-DAG: DebugTypeMember [[STR_M]] [[DTM_ROWMAJOR]]
+//CHECK-DAG: DebugTypeMember [[STR_M]] [[DTM]]
 
 //CHECK-DAG: [[STR_MCOL:%[0-9]+]] = OpString "mcol"
-//CHECK-DAG: DebugTypeMember [[STR_MCOL]] [[DTM_COLMAJOR]]
+//CHECK-DAG: DebugTypeMember [[STR_MCOL]] [[DTM]]
 
 //CHECK-DAG: [[STR_MROW:%[0-9]+]] = OpString "mrow"
-//CHECK-DAG: DebugTypeMember [[STR_MROW]] [[DTM_ROWMAJOR]]
+//CHECK-DAG: DebugTypeMember [[STR_MROW]] [[DTM]]
 
-// Locals (capture via DebugLocalVariable -> type -> ordering)
+// Locals refer to the same canonical matrix debug type.
 //CHECK-DAG: [[STR_M_LOCAL:%[0-9]+]] = OpString "m_local"
-//CHECK-DAG: DebugLocalVariable [[STR_M_LOCAL]] [[DTM_ROWMAJOR]]
+//CHECK-DAG: DebugLocalVariable [[STR_M_LOCAL]] [[DTM]]
 
 //CHECK-DAG: [[STR_MCOL_LOCAL:%[0-9]+]] = OpString "mcol_local"
-//CHECK-DAG: DebugLocalVariable [[STR_MCOL_LOCAL]] [[DTM_ROWMAJOR]]
+//CHECK-DAG: DebugLocalVariable [[STR_MCOL_LOCAL]] [[DTM]]
 
 //CHECK-DAG: [[STR_MROW_LOCAL:%[0-9]+]] = OpString "mrow_local"
-//CHECK-DAG: DebugLocalVariable [[STR_MROW_LOCAL]] [[DTM_ROWMAJOR]]
+//CHECK-DAG: DebugLocalVariable [[STR_MROW_LOCAL]] [[DTM]]
+
+// Reject the unsupported row-vector DebugTypeMatrix form anywhere in the module.
+//CHECK_NO_ROW_VECTOR: OpCapability Shader
+//CHECK_NO_ROW_VECTOR-NOT: OpExtInst %void {{.*}} DebugTypeMatrix {{.*}} %false
+//CHECK_NO_ROW_VECTOR: OpFunctionEnd
 


### PR DESCRIPTION
Emit DebugTypeMatrix in SPIR-V's column-vector form consistently, while RowMajor and ColMajor member decorations independently describe buffer storage. Normalize matrix types before debug-type caching so layout variants of the same logical matrix shape share one canonical debug type.

Update the matrix-layout tests to verify the canonical vector shape and shared debug type across buffer and non-buffer uses, while explicit and command-line layouts still control buffer storage decorations.

Fixes #12757