### PR TITLE
Skip SlangPy CI trigger for docs-only PRs

### DIFF
--- a/.github/actions/docs-only-filter/action.yml
+++ b/.github/actions/docs-only-filter/action.yml
@@ -1,0 +1,39 @@
+name: Docs-only filter
+
+description: >
+  Classify a list of changed file paths as documentation-only or not, so
+  callers can skip expensive build/test/dispatch work for PRs that only
+  touch documentation. Shared by ci.yml (which supplies the list via `git
+  diff`) and ci-slangpy-trigger-test.yml (which supplies the list via the
+  GitHub API, since it runs under pull_request_target and must not check
+  out fork-controlled code).
+
+inputs:
+  files:
+    description: "Newline-separated list of changed file paths"
+    required: true
+
+outputs:
+  should-run:
+    description: "'false' if the change set is documentation-only, 'true' otherwise"
+    value: ${{ steps.filter.outputs.should-run }}
+
+runs:
+  using: composite
+  steps:
+    - id: filter
+      shell: bash
+      env:
+        FILES: ${{ inputs.files }}
+      run: |
+        shouldRun=true
+        if echo "$FILES" | grep -Eqx 'docs/(command-line-slangc-reference.md|user-guide/a4-02-reference-capability-atoms.md)'; then
+          echo "Generated reference document changed, running checks"
+          shouldRun=true
+        elif echo "$FILES" | grep -qvE '^(docs/|LICENSES/|LICENSE$|\.claude/|.*\.md$|\.coderabbit\.yaml$)'; then
+          shouldRun=true
+        else
+          echo "Only documentation files changed, skipping"
+          shouldRun=false
+        fi
+        echo "should-run=$shouldRun" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-slangpy-trigger-test.yml
+++ b/.github/workflows/ci-slangpy-trigger-test.yml
@@ -28,9 +28,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  trigger-slangpy-tests:
+  filter:
     runs-on: ubuntu-latest
     if: (github.event_name == 'pull_request_target' && github.event.pull_request.draft != true) || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group'
+    outputs:
+      should-run: ${{ steps.filter.outputs.should-run }}
+    steps:
+      - name: Determine PR number
+        id: pr_number
+        run: |
+          echo "number=${{ github.event.pull_request.number || inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+      # A minimal checkout pinned to master, just to get the composite
+      # action definition. This never touches PR/fork content: the ref is
+      # explicit rather than relying on checkout's default (which for
+      # pull_request_target does already resolve to the base branch).
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        if: steps.pr_number.outputs.number != ''
+        with:
+          ref: master
+          sparse-checkout: .github/actions/docs-only-filter
+      - name: List changed files
+        id: changed_files
+        if: steps.pr_number.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr_number.outputs.number }}
+        run: |
+          files="$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')"
+          {
+            echo "files<<EOF"
+            echo "$files"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - id: filter
+        if: steps.pr_number.outputs.number != ''
+        uses: ./.github/actions/docs-only-filter
+        with:
+          files: ${{ steps.changed_files.outputs.files }}
+
+  trigger-slangpy-tests:
+    needs: [filter]
+    runs-on: ubuntu-latest
+    if: needs.filter.outputs.should-run != 'false'
 
     steps:
       - name: Get PR info (manual trigger)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: "2"
-      - id: filter
+      - name: Diff changed files
+        id: diff
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
@@ -32,23 +33,25 @@ jobs:
             BASE=HEAD^1
           fi
 
-          shouldRun=true
           if files="$(git diff --name-only "${BASE}...HEAD")"; then
-            # Git diff succeeded, check if non-documentation files were changed
-            if echo "$files" | grep -Eqx 'docs/(command-line-slangc-reference.md|user-guide/a4-02-reference-capability-atoms.md)'; then
-              echo "Generated reference document changed, running checks"
-              shouldRun=true
-            elif echo "$files" | grep -qvE '^(docs/|LICENSES/|LICENSE$|\.claude/|.*\.md$|\.coderabbit\.yaml$)'; then
-              shouldRun=true
-            else
-              echo "Only documentation files changed, skipping remaining steps"
-              shouldRun=false
-            fi
+            {
+              echo "files<<EOF"
+              echo "$files"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "diff-ok=true" >> "$GITHUB_OUTPUT"
           else
             echo "Git diff failed, conservatively running tests"
-            shouldRun=true
+            echo "diff-ok=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "should-run=$shouldRun" >> "$GITHUB_OUTPUT"
+      - id: filter_docs
+        if: steps.diff.outputs.diff-ok == 'true'
+        uses: ./.github/actions/docs-only-filter
+        with:
+          files: ${{ steps.diff.outputs.files }}
+      - id: filter
+        run: |
+          echo "should-run=${{ steps.diff.outputs.diff-ok == 'false' || steps.filter_docs.outputs.should-run }}" >> "$GITHUB_OUTPUT"
 
   # Low-priority gate. This job runs for every PR/dispatch that needs CI, but
   # only nv-slang-bot[bot] workflow_dispatch runs can ever yield. Those are the


### PR DESCRIPTION
## Motivation

Regular CI (`ci.yml`) skips build/test jobs for PRs that only touch documentation (e.g. #12601, which only changed `.github/copilot-instructions.md`), via the docs-only `filter` job. `ci-slangpy-trigger-test.yml`, which dispatches a SlangPy CI run against every Slang PR, had no equivalent check, so a pure docs change still queued a SlangPy CI run that cannot exercise anything the change touched.

## Proposed solution

Add the same docs-only classification to `ci-slangpy-trigger-test.yml`'s trigger job. Rather than duplicating the grep pattern that already exists in `ci.yml`, factor the classification into a shared composite action, `.github/actions/docs-only-filter`, and have both workflows call it. This keeps one source of truth for "which paths count as docs-only."

The two callers differ only in how they obtain the changed-file list, which the composite action doesn't need to know about:
- `ci.yml` already does a full checkout for its build/test jobs, so it keeps using `git diff --name-only` against the merge base.
- `ci-slangpy-trigger-test.yml` runs under `pull_request_target` (needed so `SLANGPY_DISPATCH_TOKEN` is available for fork PRs) and must never check out or execute PR/fork-controlled code. It instead fetches the changed-file list via the GitHub API (`gh api .../pulls/<n>/files`), and does a minimal, `master`-pinned, sparse checkout solely to pull in the composite action's own `action.yml` definition (never PR content).

## Change summary

| File | Change |
|---|---|
| `.github/actions/docs-only-filter/action.yml` | New composite action: takes a newline-separated `files` input, outputs `should-run` (`false` if the change set is documentation-only). |
| `.github/workflows/ci.yml` | `filter` job's `git diff` step now only produces the file list; classification is delegated to the composite action. Preserves the existing "git diff failed → conservatively run" fallback. |
| `.github/workflows/ci-slangpy-trigger-test.yml` | New `filter` job: resolves the PR number (from `pull_request_target`/`workflow_dispatch`/unresolved for `merge_group`), lists changed files via the GitHub API, and calls the composite action. `trigger-slangpy-tests` now `needs: [filter]` and only runs when `should-run != 'false'`. |

## Concepts and vocabulary

- **Docs-only filter**: the existing `ci.yml` pattern that skips expensive build/test jobs when a diff only touches `docs/`, `LICENSE(S)`, `.claude/`, `*.md`, or `.coderabbit.yaml` — except the two generated reference docs (`docs/command-line-slangc-reference.md`, `docs/user-guide/a4-02-reference-capability-atoms.md`), which always run checks since they're validated against generator output.
- **`pull_request_target`**: a GitHub Actions trigger that runs workflow code from the base branch (not the PR head) with access to repo secrets, used here so the `SLANGPY_DISPATCH_TOKEN` secret is available even for fork PRs. Because the workflow code is trusted but the event still originates from a possibly-untrusted fork, the workflow must avoid checking out or executing anything from the PR head.

## Process report

- **Why a composite action instead of duplicating the shell block**: the original version of this PR (before this revision) copy-pasted the `ci.yml` classification logic verbatim into `ci-slangpy-trigger-test.yml`. That's a second source of truth for the same policy (which paths are "docs-only"), which will drift the next time someone updates one copy and forgets the other. Factoring it into `.github/actions/docs-only-filter` — following the existing pattern of shared composite actions in `.github/actions/` (`check-disk-space`, `common-setup`, etc.) — makes the two workflows visibly call the same logic.
- **Why the file-list acquisition isn't also shared**: `git diff` requires a full checkout of the PR's commits, which `ci-slangpy-trigger-test.yml` must not do under `pull_request_target` (that would mean checking out and, if any step ran commands over it, potentially executing fork-controlled code with secrets in scope). The GitHub API route (`gh api repos/.../pulls/<n>/files`) gets the file list without ever fetching fork content. This is a real constraint that differs between the two callers, not an accidental shape — so it correctly lives in each caller, not the shared action.
- **Why the checkout in `ci-slangpy-trigger-test.yml` pins `ref: master`**: `actions/checkout`'s default ref for `pull_request_target` already resolves to the base branch, but leaving it implicit is easy to misread as "checks out the PR." The explicit `ref: master` matches the workflow's own trigger scoping (`pull_request_target.branches: [master]`, `merge_group.branches: [master]`) and makes the "never touches PR content" invariant visible without needing to know `actions/checkout`'s default-ref behavior for this event type. It's also `sparse-checkout`-scoped to just `.github/actions/docs-only-filter`.
- **Why `merge_group` still always triggers SlangPy CI**: at merge-queue time there's no cheap way to resolve a PR number to fetch a file list for without parsing the queue ref (`gh-readonly-queue/.../pr-<n>-<sha>`), and `merge_group` volume is much lower than PR volume, so the `filter` job's PR-number-resolution step is skipped for `merge_group` and `should-run` stays unset, which `trigger-slangpy-tests`'s `if: needs.filter.outputs.should-run != 'false'` treats as "run" (the conservative default). This matches current (pre-PR) behavior for merge_group exactly — no regression, and no incentive to reduce SlangPy coverage at the point where a PR is about to land.
- **Why `trigger-slangpy-tests`'s guard is `!= 'false'` rather than `== 'true'`**: this makes the check-not-run branch explicit (only skip when the filter job actually said so) rather than implicit (skip whenever the output isn't exactly `'true'`), so a filter-job failure or skip (e.g. draft PR, or the `merge_group` case above) fails open to "run SlangPy tests" instead of silently skipping them.