### PR TITLE
Add Falcor 2 perf bridge smoke workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,7 @@ self-hosted-runner:
     - build
     - falcor
     - falcor-bridge
+    - falcor2-perf-bridge
     - GCP
     - GCP-T4
     - GPU

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -238,11 +238,12 @@ PR against your branch, so a failed check can be fixed without a local checkout.
 
 ## 7. Manual only
 
-| Workflow                         | Purpose                                                     |
-| -------------------------------- | ----------------------------------------------------------- |
-| `ci-retry.yml`                   | Waits for a run to finish, then reruns its failed jobs.     |
-| `perf-compile-release-sweep.yml` | Backfills compile-performance history across past releases. |
-| `check-spirv-tools.yml`          | Placeholder for a SPIRV-Tools tip-of-tree check.            |
+| Workflow                           | Purpose                                                     |
+| ---------------------------------- | ----------------------------------------------------------- |
+| `ci-falcor2-perf-bridge-smoke.yml` | Manual smoke test for the Falcor 2 perf bridge prototype.   |
+| `ci-retry.yml`                     | Waits for a run to finish, then reruns its failed jobs.     |
+| `perf-compile-release-sweep.yml`   | Backfills compile-performance history across past releases. |
+| `check-spirv-tools.yml`            | Placeholder for a SPIRV-Tools tip-of-tree check.            |
 
 ## 8. Composite actions
 

--- a/.github/workflows/ci-falcor2-perf-bridge-smoke.yml
+++ b/.github/workflows/ci-falcor2-perf-bridge-smoke.yml
@@ -1,0 +1,30 @@
+name: CI Falcor 2 Perf Bridge Smoke
+
+# Manual bridge smoke. Keep this workflow narrow: call the runner-local
+# entrypoint with a fixed target selector and let the configured bridge own the
+# implementation.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  falcor2-perf-bridge-smoke:
+    name: Falcor 2 perf bridge smoke
+    timeout-minutes: 30
+    runs-on: [Linux, self-hosted, X64, falcor2-perf-bridge]
+    # Keep this public workflow thin, matching ci-falcor-test.yml.
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Request bridge smoke command
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLANG_CI_BRIDGE_TARGET: falcor2-perf-smoke
+        run: |
+          set -euo pipefail
+          /opt/slang-ci/run-external-ci


### PR DESCRIPTION
## Summary
- Add a manual Falcor 2 perf bridge smoke workflow.
- Register the workflow runner label for actionlint.
- Add the workflow to the manual-only workflow list.

## Testing
- `actionlint .github/workflows/ci-falcor2-perf-bridge-smoke.yml`
- `shellcheck -s bash -` for the workflow run block
- `git diff --check`