### PR TITLE
Fix SV_InstanceID on Metal to exclude the base instance

### DIFF
--- a/docs/user-guide/a2-02-metal-target-specific.md
+++ b/docs/user-guide/a2-02-metal-target-specific.md
@@ -40,7 +40,7 @@ The system-value semantics are translated to the following Metal attributes:
 | `SV_GroupID`                | `[[threadgroup_position_in_grid]]`                   |
 | `SV_GroupThreadID`          | `[[thread_position_in_threadgroup]]`                 |
 | `SV_GroupIndex`             | Calculated from `SV_GroupThreadID` and group extents |
-| `SV_InstanceID`             | `[[instance_id]]`                                    |
+| `SV_InstanceID`             | `[[instance_id]] - [[base_instance]]`                |
 | `SV_IsFrontFace`            | `[[front_facing]]`                                   |
 | `SV_PointSize`              | `[[point_size]]`                                     |
 | `SV_PointCoord`             | `[[point_coord]]`                                    |
@@ -55,6 +55,10 @@ The system-value semantics are translated to the following Metal attributes:
 | `SV_VulkanInstanceID`       | `[[instance_id]]`                                    |
 | `SV_VulkanSamplePosition`   | `(Not supported)`                                    |
 | `SV_VulkanVertexID`         | `[[vertex_id]]`                                      |
+
+_Note_ that `SV_InstanceID` counts from zero within a draw call, as in D3D, while Metal's
+`[[instance_id]]` includes the base instance, so the two are not the same value. Use
+`SV_VulkanInstanceID` for direct access to `[[instance_id]]`.
 
 Custom semantics are mapped to user attributes:
 

--- a/docs/user-guide/a2-03-wgsl-target-specific.md
+++ b/docs/user-guide/a2-03-wgsl-target-specific.md
@@ -56,6 +56,10 @@ The system-value semantics are translated to the following WGSL code.
 | SV_VulkanSamplePosition | *Not supported* |
 | SV_VulkanVertexID | `@builtin(vertex_index)` |
 
+_Note_ that `@builtin(instance_index)` counts from `firstInstance`, so `SV_InstanceID` includes the
+base instance on WGSL, unlike on D3D, SPIR-V and Metal. WGSL has no base-instance builtin to
+subtract, and `SV_StartInstanceLocation` is not supported.
+
 
 Supported HLSL features when targeting WGSL
 -------------------------------------------

--- a/source/slang/slang-ir-legalize-varying-params.cpp
+++ b/source/slang/slang-ir-legalize-varying-params.cpp
@@ -4258,6 +4258,16 @@ protected:
                 break;
             }
         case SystemValueSemanticName::InstanceID:
+            {
+                // [[instance_id]] includes the base instance; SV_InstanceID does not. Unlike the
+                // other special values, the normal path still runs after the special handler:
+                // it decorates and converts the parameter, and the handler only adds the
+                // subtraction.
+                result.isSpecial = true;
+                result.systemValueName = toSlice("instance_id");
+                result.permittedTypes.add(builder.getBasicType(BaseType::UInt));
+                break;
+            }
         case SystemValueSemanticName::VulkanInstanceID:
             {
                 result.systemValueName = toSlice("instance_id");
@@ -4324,6 +4334,8 @@ protected:
         case SystemValueSemanticName::VertexID:
         case SystemValueSemanticName::VulkanVertexID:
             {
+                // SV_VertexID still includes [[base_vertex]], the same mismatch SV_InstanceID
+                // corrects above.
                 result.systemValueName = toSlice("vertex_id");
                 result.permittedTypes.add(builder.getBasicType(BaseType::UInt));
                 break;
@@ -4468,6 +4480,22 @@ protected:
         return elementVarLayoutBuilder.build();
     }
 
+    // Find the entry point's parameter carrying the given system value semantic, if any. At most
+    // one parameter carries a given semantic, so the first match is the only one.
+    IRInst* findSystemValueParam(const EntryPointInfo& entryPoint, SystemValueSemanticName name)
+        const
+    {
+        for (auto item : collectSystemValFromEntryPoint(entryPoint))
+        {
+            UnownedStringSlice semanticName;
+            UnownedStringSlice semanticIndex;
+            splitNameAndIndex(item.attrName.getUnownedSlice(), semanticName, semanticIndex);
+            if (convertSystemValueSemanticNameToEnum(String(semanticName)) == name)
+                return item.var;
+        }
+        return nullptr;
+    }
+
     void handleSpecialSystemValue(
         const EntryPointInfo& entryPoint,
         SystemValLegalizationWorkItem& workItem,
@@ -4483,21 +4511,50 @@ protected:
             var->replaceUsesWith(val);
             var->removeAndDeallocate();
         }
+        else if (info.systemValueNameEnum == SystemValueSemanticName::InstanceID)
+        {
+            // `var` stays the [[instance_id]] parameter; its uses read `var - base_instance`.
+            // Snapshot the uses first so the subtraction's own operand is not redirected.
+            List<IRUse*> uses;
+            for (auto use = var->firstUse; use; use = use->nextUse)
+                uses.add(use);
+
+            // Reuse a declared SV_StartInstanceLocation: Metal rejects a second [[base_instance]].
+            IRInst* baseInstance =
+                findSystemValueParam(entryPoint, SystemValueSemanticName::StartInstanceLocation);
+
+            IRBuilder svBuilder(builder.getModule());
+            svBuilder.setInsertBefore(entryPoint.entryPointFunc->getFirstOrdinaryInst());
+            if (!baseInstance)
+            {
+                // Already the permitted uint, and the emitter reads the attribute from the
+                // decoration, so it needs neither a layout nor its own legalization;
+                // legalizeSystemValueParameters collected its work list before this loop, so
+                // the new parameter is never revisited either.
+                baseInstance = svBuilder.emitParam(svBuilder.getUIntType());
+                svBuilder.addTargetSystemValueDecoration(baseInstance, toSlice("base_instance"));
+                svBuilder.addNameHintDecoration(baseInstance, toSlice("base_instance"));
+            }
+            if (baseInstance->getFullType() != var->getFullType())
+            {
+                // The front end only admits scalar integers for SV_InstanceID, so this converts.
+                baseInstance = tryConvertValue(svBuilder, baseInstance, var->getFullType());
+                SLANG_ASSERT(baseInstance);
+            }
+            // The normal path still legalizes `var` (and a reused base declared after it) and
+            // redirects their uses here to the converted values.
+            auto baseRelativeInstanceId = svBuilder.emitSub(var->getFullType(), var, baseInstance);
+            for (auto use : uses)
+                svBuilder.replaceOperand(use, baseRelativeInstanceId);
+        }
         else if (info.systemValueNameEnum == SystemValueSemanticName::GroupIndex)
         {
             // Ensure we have a cached "sv_groupthreadid" in our entry point
             if (!entryPointToGroupThreadId.containsKey(entryPoint.entryPointFunc))
             {
-                auto systemValWorkItems = collectSystemValFromEntryPoint(entryPoint);
-                for (auto i : systemValWorkItems)
-                {
-                    auto indexAsStringGroupThreadId = String(i.attrIndex);
-                    if (getSystemValueInfo(i.attrName, &indexAsStringGroupThreadId, i.var)
-                            .systemValueNameEnum == SystemValueSemanticName::GroupThreadID)
-                    {
-                        entryPointToGroupThreadId[entryPoint.entryPointFunc] = i.var;
-                    }
-                }
+                if (auto groupThreadId =
+                        findSystemValueParam(entryPoint, SystemValueSemanticName::GroupThreadID))
+                    entryPointToGroupThreadId[entryPoint.entryPointFunc] = groupThreadId;
                 if (!entryPointToGroupThreadId.containsKey(entryPoint.entryPointFunc))
                 {
                     // Add the missing groupthreadid needed to compute sv_groupindex
@@ -4943,6 +5000,8 @@ protected:
         case SystemValueSemanticName::InstanceID:
         case SystemValueSemanticName::VulkanInstanceID:
             {
+                // instance_index includes firstInstance, and WGSL has no base_instance builtin
+                // to subtract, so SV_InstanceID cannot be made HLSL-accurate here.
                 result.systemValueName = toSlice("instance_index");
                 result.permittedTypes.add(builder.getUIntType());
             }

--- a/tests/diagnostics/sv-semantic-type-validation.slang
+++ b/tests/diagnostics/sv-semantic-type-validation.slang
@@ -15,6 +15,8 @@
 // Tests for unsized-array element-type path in isSemanticTypeCompatible:
 //TEST:SIMPLE(filecheck=CHECK14): -target hlsl -entry vsClipDistanceFloat -stage vertex
 //DIAGNOSTIC_TEST:SIMPLE(diag=CHECK15): -target hlsl -entry vsClipDistanceInt -stage vertex
+// The Metal SV_InstanceID rewrite relies on this front-end check admitting only scalars:
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK16): -target metal -entry vsVectorInstanceID -stage vertex
 
 // Test type validation for system value semantics.
 // Each SV_ semantic declares its accepted types. Shape mismatches (e.g., vector for a
@@ -131,5 +133,13 @@ float4 vsClipDistanceInt(uint id: SV_VertexID, out int cd[4]: SV_ClipDistance) :
 {
     for (int i = 0; i < 4; ++i)
         cd[i] = 0;
+    return float4(0, 0, 0, 1);
+}
+
+// Test 16: uint2 is rejected for SV_InstanceID on every target, before Metal's base_instance rewrite
+[shader("vertex")]
+float4 vsVectorInstanceID(uint2 id: SV_InstanceID) : SV_Position
+//CHECK16:                      ^^ type 'vector<uint,2>' is not valid for system value semantic 'SV_InstanceID'; expected 'uint'
+{
     return float4(0, 0, 0, 1);
 }

--- a/tests/metal/stage-in.slang
+++ b/tests/metal/stage-in.slang
@@ -36,7 +36,7 @@
 // METAL-NEXT:    float4 color{{.*}} {{\[\[}}attribute(1){{\]\]}};
 // METAL-NEXT:};
 
-// METAL: {{\[\[}}vertex{{\]\]}} [[vertexOutput]] main_vertex(vertexInput{{.*}}{{\[\[}}stage_in{{\]\]}}, uint vid{{.*}}{{\[\[}}vertex_id{{\]\]}}, uint instanceID{{.*}} {{\[\[}}instance_id{{\]\]}})
+// METAL: {{\[\[}}vertex{{\]\]}} [[vertexOutput]] main_vertex(vertexInput{{.*}}{{\[\[}}stage_in{{\]\]}}, uint vid{{.*}}{{\[\[}}vertex_id{{\]\]}}, uint instanceID{{.*}} {{\[\[}}instance_id{{\]\]}}, uint base_instance{{.*}} {{\[\[}}base_instance{{\]\]}})
 
 // METALLIB: define {{.*}} @main_vertex
 // METALLIB: define {{.*}} @main_fragment

--- a/tests/metal/sv-instance-id.slang
+++ b/tests/metal/sv-instance-id.slang
@@ -1,0 +1,71 @@
+// [[instance_id]] counts from the base instance, SV_InstanceID counts from zero, and
+// SV_VulkanInstanceID has gl_InstanceIndex semantics, so only SV_InstanceID subtracts.
+
+//TEST:SIMPLE(filecheck=UINT): -target metal -stage vertex -entry vertUint
+//TEST:SIMPLE(filecheck=HLSL): -target metal -stage vertex -entry vertMain
+//TEST:SIMPLE(filecheck=VULKAN): -target metal -stage vertex -entry vertVulkan
+//TEST:SIMPLE(filecheck=BOTH): -target metal -stage vertex -entry vertBoth
+//TEST:SIMPLE(filecheck=MIXED): -target metal -stage vertex -entry vertMixed
+//TEST:SIMPLE(filecheck=BOTHINT): -target metal -stage vertex -entry vertBothInt
+//TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage vertex -entry vertUint
+//TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage vertex -entry vertMain
+//TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage vertex -entry vertVulkan
+//TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage vertex -entry vertBoth
+//TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage vertex -entry vertMixed
+//TEST:SIMPLE(filecheck=METALLIB): -target metallib -stage vertex -entry vertBothInt
+
+// METALLIB: result code = 0
+
+// UINT: vertUint(uint {{[^,]*}}instance_id]], uint {{[^,]*}}base_instance]])
+// UINT: i{{[0-9_]*}} - base_instance{{[0-9_]*}}
+[shader("vertex")]
+float4 vertUint(uint i : SV_InstanceID) : SV_Position
+{
+    return i;
+}
+
+// HLSL-DAG: instance_id]]
+// HLSL-DAG: base_instance]]
+// HLSL: int(i{{[0-9_]*}}) - int(base_instance{{[0-9_]*}})
+[shader("vertex")]
+float4 vertMain(int i : SV_InstanceID) : SV_Position
+{
+    return i;
+}
+
+// VULKAN: instance_id]])
+// VULKAN-NOT: base_instance
+[shader("vertex")]
+float4 vertVulkan(uint i : SV_VulkanInstanceID) : SV_Position
+{
+    return i;
+}
+
+// An explicit SV_StartInstanceLocation is reused rather than declared a second time.
+// BOTH: vertBoth(uint {{[^,]*}}instance_id]], uint {{[^,]*}}base_instance]])
+// BOTH: i{{[0-9_]*}} - base{{[0-9_]*}} + base{{[0-9_]*}}
+[shader("vertex")]
+float4 vertBoth(uint i : SV_InstanceID, uint base : SV_StartInstanceLocation) : SV_Position
+{
+    return i + base;
+}
+
+// The reused parameter is converted to the declared type of SV_InstanceID.
+// MIXED: vertMixed(uint {{[^,]*}}instance_id]], uint {{[^,]*}}base_instance]])
+// MIXED: int [[BASE:[A-Za-z_0-9]+]] = int(base{{[0-9_]*}});
+// MIXED: int(i{{[0-9_]*}}) - [[BASE]] + [[BASE]]
+[shader("vertex")]
+float4 vertMixed(int i : SV_InstanceID, uint base : SV_StartInstanceLocation) : SV_Position
+{
+    return i + int(base);
+}
+
+// A reused parameter legalized after SV_InstanceID is converted ahead of the subtraction.
+// BOTHINT: vertBothInt(uint {{[^,]*}}instance_id]], uint {{[^,]*}}base_instance]])
+// BOTHINT: int [[BASE:[A-Za-z_0-9]+]] = int(base{{[0-9_]*}});
+// BOTHINT: int(i{{[0-9_]*}}) - [[BASE]] + [[BASE]]
+[shader("vertex")]
+float4 vertBothInt(int i : SV_InstanceID, int base : SV_StartInstanceLocation) : SV_Position
+{
+    return i + base;
+}


### PR DESCRIPTION
HLSL defines SV_InstanceID as the instance number within the draw, excluding the base instance. MSL's [[instance_id]] already includes it, so a Slang vertex shader compiled for Metal read `base + i` where the language promises `i`. The usual idiom for an absolute instance index, SV_InstanceID + SV_StartInstanceLocation, therefore evaluated to `base * 2 + i`: correct while the base is zero, and reading past the instance's own data as soon as a draw starts anywhere else.

The SPIR-V path already handles this in legalizeTargetBuiltinVar (slang-ir-glsl-legalize.cpp) by rewriting loads of the HLSL builtin to gl_InstanceIndex - gl_BaseInstance. The Metal legalization in slang-ir-legalize-varying-params.cpp maps a semantic to a single builtin name in getSystemValueInfo, so the subtraction goes through the special-value hook that already synthesizes SV_GroupIndex from SV_GroupThreadID: SV_InstanceID keeps its [[instance_id]] parameter, and handleSpecialSystemValue redirects every use of it to `instance_id - base_instance`, reusing an SV_StartInstanceLocation parameter when the entry point declares one (Metal rejects a duplicate [[base_instance]]) and appending one otherwise. The arithmetic is done in the parameter's declared type so the existing type-conversion path applies uniformly.

SV_VulkanInstanceID has gl_InstanceIndex semantics, base included, and shared a switch arm with SV_InstanceID; it now keeps mapping straight to [[instance_id]] on its own.

WGSL has the same shape (both semantics map to instance_index, which also counts from firstInstance) but no base_instance builtin to subtract, so it cannot be corrected in the compiler; the mapping is left as is with a note.

tests/metal/stage-in.slang pins the vertex entry's full signature, which now carries the synthesized [[base_instance]] parameter.

Contributes to #12883