### PR TITLE
Fix Metal mesh index emission for compound indices and point topology

### DIFF
--- a/source/slang/slang-emit-metal.cpp
+++ b/source/slang/slang-emit-metal.cpp
@@ -1070,21 +1070,30 @@ bool MetalSourceEmitter::tryEmitInstExprImpl(IRInst* inst, const EmitOpInfo& inO
     case kIROp_MetalSetIndices:
         {
             auto setIndices = as<IRMetalSetIndices>(inst);
-            const auto indices = as<IRVectorType>(setIndices->getElementValue()->getDataType());
-            UInt numIndices = as<IRIntLit>(indices->getElementCount())->getValue();
-            for (UInt i = 0; i < numIndices; ++i)
+            auto value = setIndices->getElementValue();
+            // Scalar for point topology, uint2/uint3 for lines/triangles.
+            auto vectorType = as<IRVectorType>(value->getDataType());
+            SLANG_ASSERT(vectorType || as<IRBasicType>(value->getDataType()));
+            IRIntegerValue numIndices = vectorType ? getIntVal(vectorType->getElementCount()) : 1;
+            for (IRIntegerValue i = 0; i < numIndices; ++i)
             {
                 m_writer->emit("_slang_mesh.set_index(");
-                emitOperand(setIndices->getIndex(), getInfo(EmitOp::General));
+                emitOperand(
+                    setIndices->getIndex(),
+                    leftSide(getInfo(EmitOp::General), getInfo(EmitOp::Mul)));
                 m_writer->emit("*");
-                m_writer->emitUInt64(numIndices);
+                m_writer->emitInt64(numIndices);
                 m_writer->emit("+");
-                m_writer->emitUInt64(i);
-                m_writer->emit(",(");
-                emitOperand(setIndices->getElementValue(), getInfo(EmitOp::General));
-                m_writer->emit(")[");
-                m_writer->emitUInt64(i);
-                m_writer->emit("]);\n");
+                m_writer->emitInt64(i);
+                m_writer->emit(",");
+                emitOperand(value, leftSide(getInfo(EmitOp::General), getInfo(EmitOp::Postfix)));
+                if (vectorType)
+                {
+                    m_writer->emit("[");
+                    m_writer->emitInt64(i);
+                    m_writer->emit("]");
+                }
+                m_writer->emit(");\n");
             }
             return true;
         }

--- a/tests/metal/mesh-index-expression.slang
+++ b/tests/metal/mesh-index-expression.slang
@@ -1,0 +1,95 @@
+// Writing `tris[pbase + 1u]` must scale the whole index, `(pbase + 1U)*3`, not `pbase + 1U*3`.
+// A scalar `out indices uint` (point topology) has one index per primitive and no component.
+
+//TEST:SIMPLE(filecheck=TRI): -entry meshTriangles -stage mesh -target metal
+//TEST:SIMPLE(filecheck=LINE): -entry meshLines -stage mesh -target metal
+//TEST:SIMPLE(filecheck=POINT): -entry meshPoints -stage mesh -target metal
+//TEST:SIMPLE(filecheck=VALUE): -entry meshVectorValue -stage mesh -target metal
+//TEST:SIMPLE(filecheck=METALLIB): -entry meshTriangles -stage mesh -target metallib
+//TEST:SIMPLE(filecheck=METALLIB): -entry meshLines -stage mesh -target metallib
+//TEST:SIMPLE(filecheck=METALLIB): -entry meshPoints -stage mesh -target metallib
+//TEST:SIMPLE(filecheck=METALLIB): -entry meshVectorValue -stage mesh -target metallib
+
+// METALLIB: result code = 0
+
+struct V { float4 pos : SV_Position; };
+
+[shader("mesh")]
+[numthreads(32, 1, 1)]
+[outputtopology("triangle")]
+void meshTriangles(uint lane : SV_GroupIndex, out vertices V verts[128], out indices uint3 tris[64])
+{
+    SetMeshOutputCounts(128, 64);
+    uint vbase = lane * 4u;
+    uint pbase = lane * 2u;
+    for (uint i = 0u; i < 4u; ++i)
+    {
+        V v;
+        v.pos = float4(float(i), 0.0, 0.0, 1.0);
+        verts[vbase + i] = v;
+    }
+
+    // TRI: _slang_mesh.set_index(pbase{{.*}}*3+0,
+    // TRI: _slang_mesh.set_index(pbase{{.*}}*3+1,
+    // TRI: _slang_mesh.set_index(pbase{{.*}}*3+2,
+    tris[pbase] = uint3(vbase, vbase + 1u, vbase + 2u);
+
+    // TRI: _slang_mesh.set_index((pbase{{.*}} + 1U)*3+0,
+    // TRI: _slang_mesh.set_index((pbase{{.*}} + 1U)*3+1,
+    // TRI: _slang_mesh.set_index((pbase{{.*}} + 1U)*3+2,
+    tris[pbase + 1u] = uint3(vbase, vbase + 2u, vbase + 3u);
+}
+
+[shader("mesh")]
+[numthreads(32, 1, 1)]
+[outputtopology("line")]
+void meshLines(uint lane : SV_GroupIndex, out vertices V verts[128], out indices uint2 lines[64])
+{
+    SetMeshOutputCounts(128, 64);
+    uint vbase = lane * 2u;
+    for (uint i = 0u; i < 2u; ++i)
+    {
+        V v;
+        v.pos = float4(float(i), 0.0, 0.0, 1.0);
+        verts[vbase + i] = v;
+    }
+
+    // LINE: _slang_mesh.set_index(({{.*}} + 1U)*2+0,
+    // LINE: _slang_mesh.set_index(({{.*}} + 1U)*2+1,
+    lines[lane + 1u] = uint2(vbase, vbase + 1u);
+}
+
+[shader("mesh")]
+[numthreads(32, 1, 1)]
+[outputtopology("point")]
+void meshPoints(uint lane : SV_GroupIndex, out vertices V verts[128], out indices uint points[64])
+{
+    SetMeshOutputCounts(128, 64);
+    V v;
+    v.pos = float4(float(lane), 0.0, 0.0, 1.0);
+    verts[lane] = v;
+
+    // POINT: _slang_mesh.set_index(({{.*}} + 1U)*1+0,{{[a-z_0-9]+}});
+    points[lane + 1u] = lane;
+}
+
+[shader("mesh")]
+[numthreads(32, 1, 1)]
+[outputtopology("triangle")]
+void meshVectorValue(
+    uint lane : SV_GroupIndex,
+    uniform uint3 offset,
+    out vertices V verts[128],
+    out indices uint3 tris[64])
+{
+    SetMeshOutputCounts(128, 64);
+    V v;
+    v.pos = float4(float(lane), 0.0, 0.0, 1.0);
+    verts[lane] = v;
+
+    // A value below postfix precedence is parenthesized before it is subscripted.
+    // VALUE: _slang_mesh.set_index({{.*}}*3+0,({{.*}} + {{.*}})[0]);
+    // VALUE: _slang_mesh.set_index({{.*}}*3+1,({{.*}} + {{.*}})[1]);
+    // VALUE: _slang_mesh.set_index({{.*}}*3+2,({{.*}} + {{.*}})[2]);
+    tris[lane] = uint3(lane, lane + 1u, lane + 2u) + offset;
+}


### PR DESCRIPTION
Slang models a mesh shader's index output as one write per primitive (`tris[p] = uint3(a, b, c)`), while Metal's `mesh::set_index` addresses the index buffer one index at a time. The Metal emitter therefore lowers each `MetalSetIndices` to N calls at `p*N+0 .. p*N+N-1`, but it pasted the `*N` after the primitive index emitted at `EmitOp::General`, so an index that is itself an expression was never parenthesized:

    uint pbase = lane * 2u;
    tris[pbase]      = ...;   // set_index(pbase*3+0, ...)   correct
    tris[pbase + 1u] = ...;   // set_index(pbase + 1U*3+0, ...)   pbase + 3

The second form binds the `*` to the literal and addresses `pbase + 3` instead of `(pbase + 1) * 3`. The two agree only for `pbase == 0`, so every other lane writes its second primitive into another lane's slot and the unwritten slots keep stale indices, which renders as slivers stretching to unrelated vertices.

The index is now emitted as the left operand of a multiply, via the emitter's precedence machinery (`leftSide(General, Mul)`), which is how the neighbouring `RWStructuredBufferGetElementPtr` case and every other composed expression in the emitters already do it. The written value is likewise emitted at postfix precedence before the `[i]` subscript instead of being wrapped in hand-written parentheses.

The same case also dereferenced `as<IRVectorType>` unconditionally. For `[outputtopology("point")]` the index type is a scalar `uint`, so slangc crashed with a null dereference. A scalar now counts as one index per primitive and is written without a subscript.

Contributes to #12883