### PR TITLE
Post PR board repo writes as github-actions[bot]

### DIFF
--- a/.github/pr-board-sync-templates/README.md
+++ b/.github/pr-board-sync-templates/README.md
@@ -43,8 +43,13 @@ the reference for what slang runs.
 4. Ensure the org-level secret `SLANG_PR_BOT_TOKEN` (a dedicated bot PAT with org
    Projects RW + Members read; repo Contents read, Pull requests write, Issues
    write, Metadata read) is available to the repo. The callers map only that
-   secret; the reusable workflow uses it for every call, so callers should keep
-   `permissions: {}` to drop the unused `GITHUB_TOKEN` scopes.
+   secret. Repo-scoped writes are made as `github-actions[bot]`, so each calling
+   job grants `issues: write` (assignees, linked issues, and comments) and
+   `pull-requests: write` (review requests). The reusable workflow uses the PAT
+   for org-team reads and ProjectsV2 writes, which `GITHUB_TOKEN` cannot do, and
+   as a compatibility fallback for assignment/reviewer writes while existing
+   callers roll out these grants. Comments never fall back to the PAT because
+   that would subscribe its human owner to the PR.
 
 The nightly sweep (`pr-sweep-nightly.yml`, `mode: sweep`) is the idempotent
 backstop for anything the per-event path cannot see (missed webhooks, failed runs,

--- a/.github/pr-board-sync-templates/example-pr-checks-complete.yml
+++ b/.github/pr-board-sync-templates/example-pr-checks-complete.yml
@@ -39,6 +39,11 @@ permissions: {}
 
 jobs:
   board-sync:
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/pr-board-sync-templates/example-pr-commit-status.yml
+++ b/.github/pr-board-sync-templates/example-pr-commit-status.yml
@@ -25,6 +25,11 @@ jobs:
     # (success -> recovery, failure/error -> Snagged) changes the outcome, and the
     # recompute is idempotent regardless.
     if: ${{ github.event.state != 'pending' }}
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/pr-board-sync-templates/example-pr-maintenance.yml
+++ b/.github/pr-board-sync-templates/example-pr-maintenance.yml
@@ -53,6 +53,11 @@ jobs:
     if: >-
       github.event_name != 'pull_request_review' ||
       github.event.pull_request.head.repo.fork == false
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/pr-board-sync-templates/example-pr-review-fork-apply.yml
+++ b/.github/pr-board-sync-templates/example-pr-review-fork-apply.yml
@@ -25,6 +25,11 @@ jobs:
     # Only when the bridge completed successfully (it always should; this guards
     # against a cancelled/failed relay run).
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/pr-board-sync-templates/example-pr-sweep-nightly.yml
+++ b/.github/pr-board-sync-templates/example-pr-sweep-nightly.yml
@@ -24,6 +24,11 @@ permissions: {}
 
 jobs:
   board-sweep:
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
     with:
       mode: sweep

--- a/.github/scripts/pr-write-identity.test.js
+++ b/.github/scripts/pr-write-identity.test.js
@@ -1,0 +1,135 @@
+// Unit tests for the GITHUB_TOKEN write adapter inlined in pr-board-sync.yml.
+// No deps; run with: node .github/scripts/pr-write-identity.test.js
+"use strict";
+
+const assert = require("node:assert");
+const {
+  actionsWrite,
+  repoApiPath,
+} = require("./extract-workflow-js.js").load({
+  workflow: ".github/workflows/pr-board-sync.yml",
+  block: "actions-write",
+});
+
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+function setGlobals(fetchImpl) {
+  const warnings = [];
+  global.fetch = fetchImpl;
+  global.core = { warning: (message) => warnings.push(message) };
+  global.context = { repo: { owner: "shader-slang", repo: "slang" } };
+  process.env.ACTIONS_TOKEN = "actions-token";
+  process.env.GITHUB_API_URL = "https://api.github.test";
+  return warnings;
+}
+
+test("repoApiPath targets the caller repository", () => {
+  setGlobals(async () => ({ ok: true, status: 200 }));
+  assert.strictEqual(
+    repoApiPath("/issues/42/assignees"),
+    "/repos/shader-slang/slang/issues/42/assignees",
+  );
+});
+
+test("successful writes use GITHUB_TOKEN and do not call the PAT fallback", async () => {
+  let request;
+  let fallbackCalls = 0;
+  setGlobals(async (url, options) => {
+    request = { url, options };
+    return { ok: true, status: 201 };
+  });
+
+  await actionsWrite(
+    "POST",
+    "/repos/shader-slang/slang/issues/42/assignees",
+    { assignees: ["owner"] },
+    async () => { fallbackCalls++; },
+  );
+
+  assert.strictEqual(fallbackCalls, 0);
+  assert.strictEqual(
+    request.url,
+    "https://api.github.test/repos/shader-slang/slang/issues/42/assignees",
+  );
+  assert.strictEqual(request.options.headers.authorization, "Bearer actions-token");
+  assert.deepStrictEqual(
+    JSON.parse(request.options.body),
+    { assignees: ["owner"] },
+  );
+});
+
+test("a permission denial uses the PAT fallback when one is allowed", async () => {
+  let fallbackCalls = 0;
+  const warnings = setGlobals(async () => ({
+    ok: false,
+    status: 403,
+    text: async () => "Resource not accessible by integration",
+  }));
+
+  const result = await actionsWrite(
+    "DELETE",
+    "/repos/shader-slang/slang/pulls/42/requested_reviewers",
+    { reviewers: ["ignored"] },
+    async () => {
+      fallbackCalls++;
+      return "fallback-result";
+    },
+  );
+
+  assert.strictEqual(result, "fallback-result");
+  assert.strictEqual(fallbackCalls, 1);
+  assert.match(warnings[0], /using the PAT fallback/);
+});
+
+test("comments cannot fall back to the PAT on a permission denial", async () => {
+  setGlobals(async () => ({
+    ok: false,
+    status: 403,
+    text: async () => "Resource not accessible by integration",
+  }));
+
+  await assert.rejects(
+    actionsWrite(
+      "POST",
+      "/repos/shader-slang/slang/issues/42/comments",
+      { body: "assignment notice" },
+    ),
+    /403 Resource not accessible by integration/,
+  );
+});
+
+test("non-permission failures never fall back to the PAT", async () => {
+  let fallbackCalls = 0;
+  setGlobals(async () => ({
+    ok: false,
+    status: 500,
+    text: async () => "server error",
+  }));
+
+  await assert.rejects(
+    actionsWrite(
+      "POST",
+      "/repos/shader-slang/slang/issues/42/assignees",
+      { assignees: ["owner"] },
+      async () => { fallbackCalls++; },
+    ),
+    /500 server error/,
+  );
+  assert.strictEqual(fallbackCalls, 0);
+});
+
+(async () => {
+  let passed = 0, failed = 0;
+  for (const [name, fn] of tests) {
+    try {
+      await fn();
+      passed++;
+    } catch (error) {
+      failed++;
+      console.error(`FAIL: ${name}\n  ${(error && error.stack) || error}`);
+    }
+  }
+  console.log(`${passed} passed, ${failed} failed`);
+  process.exit(failed ? 1 : 0);
+})();

--- a/.github/workflows/check-workflow-scripts.yml
+++ b/.github/workflows/check-workflow-scripts.yml
@@ -1,8 +1,9 @@
 name: Check Workflow Scripts
 
 # Lightweight unit tests for the JavaScript used by our GitHub workflows
-# (committer-signal ranking + assignee/reviewer selection inlined into
-# pr-board-sync.yml, extracted at test time). This is the single home for
+# (committer-signal ranking, assignee/reviewer selection, and GITHUB_TOKEN write
+# routing inlined into pr-board-sync.yml and extracted at test time). This is the
+# single home for
 # workflow-JS test coverage: any new .github/scripts/*.test.js is picked up
 # automatically by the run step below -- no edit here needed.
 #

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -140,33 +140,15 @@ notice and asks recipients not to reply.
 
 ### The comment does not leave a human watching the PR
 
-GitHub subscribes whoever posts a comment to that PR's thread, and also lists
-them under the PR's participants. The workflow needs
+GitHub auto-subscribes whoever comments on a thread. The workflow still needs
 `SLANG_PR_BOT_TOKEN` for org-team and ProjectsV2 access, but commenting with
-that PAT would make its human owner watch every PR the workflow greets.
+that PAT would make its human owner watch every PR the workflow greets. There
+is no comment-API flag to skip that subscription.
 
-There is no way to opt out and no way to undo it with this token:
-
-- No comment API takes a "do not subscribe" flag — not REST `createComment`, not
-  GraphQL `addComment`.
-- Unsubscribing afterwards needs the `notifications` scope, which **only classic
-  PATs** have. `SLANG_PR_BOT_TOKEN` is fine-grained, and GitHub's docs state that
-  every thread-subscription REST endpoint "does not work with ... fine-grained
-  personal access tokens." The GraphQL `updateSubscription` mutation is gated the
-  same way, and notably `repo` does not substitute for it:
-
-  ```
-  INSUFFICIENT_SCOPES: The 'updateSubscription' field requires one of the
-  following scopes: ['notifications']
-  ```
-
-- Even with that scope, unsubscribing would not remove the account from the
-  participants list.
-
-So repo-scoped writes instead go through `actionsWrite`, which `fetch`es the
+Repo-scoped writes therefore go through `actionsWrite`, which `fetch`es the
 assignee, review-request, and comment endpoints with the run's `GITHUB_TOKEN`.
-Their visible actor is then `github-actions[bot]`. This is a raw `fetch` rather
-than the `github` client because `actions/github-script` provides exactly one
+Their visible actor is `github-actions[bot]`. This is a raw `fetch` rather than
+the `github` client because `actions/github-script` provides exactly one
 authenticated Octokit and it is bound to the PAT.
 
 Consequences worth knowing:

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -31,8 +31,14 @@ For each open PR the workflow:
 7. Unrequests **ignored reviewers** (e.g. `bmillsNV`) on onboarding and when
    freshly assigning an owner — not on every sweep pass for already-assigned PRs.
 
-All GitHub API calls use the org-level `SLANG_PR_BOT_TOKEN` PAT. Callers and the
-reusable workflow set `permissions: {}` so the ambient `GITHUB_TOKEN` is unused.
+Repo-scoped writes use the run's `GITHUB_TOKEN`, so assignee changes, review
+requests, and comments appear as `github-actions[bot]`. Calling jobs grant
+`issues: write` and `pull-requests: write`. The org-level
+`SLANG_PR_BOT_TOKEN` PAT remains mandatory for org-team reads and ProjectsV2
+writes, which `GITHUB_TOKEN` cannot do, and is a compatibility fallback for
+assignment/reviewer writes while existing cross-repo callers adopt the grants.
+Comments never fall back to the PAT; see
+[below](#the-comment-does-not-leave-a-human-watching-the-pr).
 
 ## Architecture
 
@@ -57,7 +63,8 @@ flowchart TB
   forkBridge -->|workflow_run| forkApply
 
   engine --> board[(Slang PR Tracking board)]
-  engine --> gh[GitHub API via SLANG_PR_BOT_TOKEN]
+  engine --> repo[Repo writes via GITHUB_TOKEN]
+  engine --> org[Org teams + ProjectsV2 via SLANG_PR_BOT_TOKEN]
 ```
 
 ### Callers in `shader-slang/slang`
@@ -131,6 +138,53 @@ reviewer for a human to consider, but is never `requestReviewers`'d — so they 
 not notified unless someone follows up. The comment is labeled as an automated
 notice and asks recipients not to reply.
 
+### The comment does not leave a human watching the PR
+
+GitHub subscribes whoever posts a comment to that PR's thread, and also lists
+them under the PR's participants. The workflow needs
+`SLANG_PR_BOT_TOKEN` for org-team and ProjectsV2 access, but commenting with
+that PAT would make its human owner watch every PR the workflow greets.
+
+There is no way to opt out and no way to undo it with this token:
+
+- No comment API takes a "do not subscribe" flag — not REST `createComment`, not
+  GraphQL `addComment`.
+- Unsubscribing afterwards needs the `notifications` scope, which **only classic
+  PATs** have. `SLANG_PR_BOT_TOKEN` is fine-grained, and GitHub's docs state that
+  every thread-subscription REST endpoint "does not work with ... fine-grained
+  personal access tokens." The GraphQL `updateSubscription` mutation is gated the
+  same way, and notably `repo` does not substitute for it:
+
+  ```
+  INSUFFICIENT_SCOPES: The 'updateSubscription' field requires one of the
+  following scopes: ['notifications']
+  ```
+
+- Even with that scope, unsubscribing would not remove the account from the
+  participants list.
+
+So repo-scoped writes instead go through `actionsWrite`, which `fetch`es the
+assignee, review-request, and comment endpoints with the run's `GITHUB_TOKEN`.
+Their visible actor is then `github-actions[bot]`. This is a raw `fetch` rather
+than the `github` client because `actions/github-script` provides exactly one
+authenticated Octokit and it is bound to the PAT.
+
+Consequences worth knowing:
+
+- Calling jobs grant `permissions: issues: write` for assignee/comment endpoints
+  and `pull-requests: write` for review-request endpoints. A called workflow can
+  never hold more permission than its caller granted.
+- During the cross-repo rollout, a 403 from an assignment or review-request
+  write falls back to the PAT, preserving existing behavior. A comment never
+  falls back because doing so would recreate the human-watcher bug; it is
+  skipped with a warning naming the missing permission.
+- For the same reason this workflow deliberately declares **no** `permissions:`
+  block of its own. Declaring write permissions here would make GitHub reject
+  the run at startup for every caller that had not added the grants, taking down
+  its board sync completely. Inheriting keeps the rollout incremental.
+- Comments made with `GITHUB_TOKEN` do not trigger further workflow runs, which
+  removes any recursion risk from this greeting.
+
 **Community PRs** also co-assign the external author (separate API call, best-effort).
 
 **Ignored reviewers** (`bmillsNV`, …) are unrequested when a new owner is assigned
@@ -147,15 +201,16 @@ per-file LOC tiebreak runs only when the top two are close.
 
 The ranking/selection logic is inlined in `pr-board-sync.yml` (between
 `extract-js:assignment:begin/end` markers); Source classification helpers live
-in `extract-js:classify:begin/end`. Unit tests extract those blocks at run time.
-Wiring outside the extract markers (`reconcileAssignment`,
-`postAssignmentComment`, and the `requestReviewers` call site) is not covered by
-those unit tests and is verified manually / after merge.
+in `extract-js:classify:begin/end`; the GITHUB_TOKEN write/fallback adapter lives
+in `extract-js:actions-write:begin/end`. Unit tests extract those blocks at run
+time. The call-site wiring in `reconcileAssignment` and
+`postAssignmentComment` is verified manually / after merge.
 
 ```bash
 node .github/scripts/pr-signal.test.js
 node .github/scripts/pr-assign.test.js
 node .github/scripts/pr-classify.test.js
+node .github/scripts/pr-write-identity.test.js
 ```
 
 ## CI rollup
@@ -186,7 +241,9 @@ When `SLANG_PR_BOT_TOKEN` is unavailable, privileged steps skip cleanly (`HAS_TO
 ## Required secret
 
 **`SLANG_PR_BOT_TOKEN`** (org-level): Projects read+write, Members read; repo
-Contents read, Pull requests write, Issues write, Metadata read.
+Contents read, Pull requests write, Issues write, Metadata read. The repo write
+permissions support the temporary compatibility fallback; org-team and
+ProjectsV2 access are why this token remains mandatory.
 
 ## Safety
 

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -50,11 +50,14 @@ name: PR Board Sync (reusable)
 #
 # Cross-repo reuse: any shader-slang repo adds a thin caller workflow that
 # declares the PR event triggers and calls this one, mapping the single required
-# secret explicitly (no `secrets: inherit`; callers should set `permissions: {}`
-# because this workflow uses the PAT for everything, not the GITHUB_TOKEN):
+# secret explicitly (no `secrets: inherit`) and granting the GITHUB_TOKEN
+# permissions its repo-scoped writes need (see "Caller permissions"):
 #
 #   jobs:
 #     board-sync:
+#       permissions:
+#         issues: write
+#         pull-requests: write
 #       uses: shader-slang/slang/.github/workflows/pr-board-sync.yml@master
 #       secrets:
 #         SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}
@@ -63,14 +66,24 @@ name: PR Board Sync (reusable)
 # defaults to the shared board's values; callers pass only the one secret.
 #
 # Required secret (a shader-slang **org-level** secret, shared org-wide):
-#   SLANG_PR_BOT_TOKEN - a dedicated bot PAT used for EVERY GitHub call this
-#     workflow makes (so growing its capabilities never changes the caller
-#     contract — you widen this PAT's scopes centrally, callers are untouched).
+#   SLANG_PR_BOT_TOKEN - a dedicated bot PAT used for org-team/ProjectsV2 calls,
+#     repo reads, and compatibility fallback writes while callers adopt the
+#     GITHUB_TOKEN grants below.
 #     Scopes needed: org Projects read+write (board) and Members read; repo
 #     Contents read, Pull requests write, Issues write, Metadata read. Members
 #     read is what Source classification needs; when a team roster remains
 #     unreadable after bounded retries, no Source is written and a later
 #     workflow run retries with a fresh in-memory cache.
+#
+# Caller permissions: repo-scoped writes are made as github-actions[bot] with the
+# run's GITHUB_TOKEN: PR/issue assignees and comments need `issues: write`, while
+# review requests need `pull-requests: write`. The PAT remains the fallback for
+# those writes while callers roll out the grants, and remains mandatory for org
+# team reads and ProjectsV2 writes, which GITHUB_TOKEN cannot do. A called
+# workflow can never hold more permission than its caller granted, so callers
+# grant both permissions on the calling job. Without them, the PAT fallback keeps
+# assignment/reviewer writes working, but the comment is skipped rather than
+# posted as the PAT owner (which would subscribe that person to the PR).
 #
 # Safety: every job runs only on PR metadata / API calls and never checks out or
 # executes PR code, so `pull_request_target` (secrets available for fork PRs) is
@@ -172,12 +185,20 @@ on:
         default: "bmillsNV"
     secrets:
       SLANG_PR_BOT_TOKEN:
-        description: "Dedicated bot PAT used for every GitHub call this workflow makes (org Projects RW + Members read; repo Contents read, Pull requests write, Issues write, Metadata read)."
+        description: "Dedicated bot PAT used for org Projects RW + Members read, repo reads, and as a compatibility fallback for repo writes while callers grant GITHUB_TOKEN Issues/Pull requests write."
         required: true
 
-# Every step authenticates with SLANG_PR_BOT_TOKEN, so the GITHUB_TOKEN is unused;
-# deny it entirely. (Callers therefore need no permissions block.)
-permissions: {}
+# NOTE: deliberately no `permissions:` block here, so this workflow's GITHUB_TOKEN
+# is exactly what the calling job granted.
+#
+# Repo-scoped writes use the run's GITHUB_TOKEN so the visible actor is
+# github-actions[bot]. It would be tempting to declare its `issues: write` and
+# `pull-requests: write` permissions here, but a called workflow may not request
+# more than its caller granted -- GitHub would reject un-updated callers at
+# STARTUP. Inheriting keeps the rollout safe: updated callers use GITHUB_TOKEN;
+# un-updated callers fall back to the PAT for assignment/reviewer writes, while
+# the comment is skipped because a PAT-authored comment would subscribe its human
+# owner. Org team reads and ProjectsV2 writes always use the PAT.
 
 jobs:
   board-sync:
@@ -528,6 +549,12 @@ jobs:
           BOT_OWNERS_TEAM: ${{ inputs.bot_owners_team }}
           MAINTAINER_TEAM: ${{ inputs.maintainer_team }}
           FALLBACK_ASSIGNEE: ${{ inputs.fallback_assignee }}
+          # The run's own GITHUB_TOKEN, used for repo-scoped writes so assignments,
+          # review requests, and comments show up as github-actions[bot]. Its reach
+          # is exactly what the calling job granted; the PAT remains available to
+          # the github-script client for org/Projects calls and compatibility
+          # fallback during the caller rollout.
+          ACTIONS_TOKEN: ${{ github.token }}
         with:
           github-token: ${{ secrets.SLANG_PR_BOT_TOKEN }}
           script: |
@@ -1488,17 +1515,62 @@ jobs:
               for (const iss of linkedIssues) {
                 if (iss.assignees?.length) continue;
                 try {
-                  await github.rest.issues.addAssignees({
+                  const args = {
                     owner: context.repo.owner, repo: context.repo.repo,
                     issue_number: iss.number, assignees: [ownerLogin],
-                  });
+                  };
+                  await actionsWrite(
+                    "POST", repoApiPath(`/issues/${iss.number}/assignees`),
+                    { assignees: args.assignees },
+                    () => github.rest.issues.addAssignees(args));
                   console.log(`assigned issue #${iss.number} -> ${ownerLogin}`);
                 } catch (error) {
                   core.warning(
-                    `could not assign issue #${iss.number} (${error.status})`);
+                    `could not assign issue #${iss.number} ` +
+                    `(${error.message || error.status})`);
                 }
               }
             }
+
+            // Make a repo-scoped write as github-actions[bot]. github-script gives
+            // us exactly one authenticated Octokit (`github`), and it is bound to
+            // SLANG_PR_BOT_TOKEN because org-team and ProjectsV2 calls require the
+            // PAT, so repo writes use the run's GITHUB_TOKEN through raw fetch.
+            //
+            // While cross-repo callers roll out GITHUB_TOKEN write permissions,
+            // assignment/reviewer writes may pass `patFallback` to preserve their
+            // previous behavior on a 403. Comments deliberately do not: posting a
+            // comment as the PAT owner would subscribe that human to the PR, the
+            // problem this identity split exists to prevent.
+            // ----- extract-js:actions-write:begin -----
+            async function actionsWrite(method, path, body, patFallback = null) {
+              const api = process.env.GITHUB_API_URL || "https://api.github.com";
+              const response = await fetch(`${api}${path}`, {
+                method,
+                headers: {
+                  authorization: `Bearer ${process.env.ACTIONS_TOKEN}`,
+                  accept: "application/vnd.github+json",
+                  "x-github-api-version": "2022-11-28",
+                  "content-type": "application/json",
+                },
+                body: body === undefined ? undefined : JSON.stringify(body),
+              });
+              if (response.status === 403 && patFallback) {
+                core.warning(
+                  `GITHUB_TOKEN cannot ${method} ${path}; using the PAT fallback. ` +
+                  `Update the calling job's issues/pull-requests permissions.`);
+                return patFallback();
+              }
+              if (!response.ok) {
+                throw new Error(
+                  `${response.status} ${(await response.text()).slice(0, 200)}`);
+              }
+            }
+
+            function repoApiPath(suffix) {
+              return `/repos/${context.repo.owner}/${context.repo.repo}${suffix}`;
+            }
+            // ----- extract-js:actions-write:end -----
 
             // Backfill a PR's assignee + reviewers (linked-issue Internal assignee
             // -> committer-signal owner -> maintainer). For Community/Bot:
@@ -1512,19 +1584,24 @@ jobs:
             // fires at most once). Linked-issue assignment is also idempotent:
             // only unassigned issues are updated, including when the PR was
             // assigned earlier or the issue was linked later.
+
+            // Posted as github-actions[bot] (see actionsWrite) so this
+            // greeting does not quietly turn the PAT's owner into a watcher of
+            // every Community/Bot PR. Best-effort: a failure here (e.g. a caller
+            // that did not grant `issues: write`) leaves the PR assigned
+            // and the reviewer requested, just without the note.
             async function postAssignmentComment(number, {
               source, assignee, suggestedReviewer,
               autoRequestedReviewer, autoRequestedHasSignal,
             }) {
               try {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner, repo: context.repo.repo,
-                  issue_number: number,
-                  body: formatAssignmentComment({
-                    source, assignee, suggestedReviewer,
-                    autoRequestedReviewer, autoRequestedHasSignal,
-                  }),
-                });
+                await actionsWrite(
+                  "POST", repoApiPath(`/issues/${number}/comments`), {
+                    body: formatAssignmentComment({
+                      source, assignee, suggestedReviewer,
+                      autoRequestedReviewer, autoRequestedHasSignal,
+                    }),
+                  });
                 if (suggestedReviewer) {
                   console.log(
                     `assignment comment for ${assignee}; suggested ${suggestedReviewer}`);
@@ -1533,7 +1610,9 @@ jobs:
                 }
               } catch (error) {
                 core.warning(
-                  `could not post assignment comment (${error.status})`);
+                  `could not post assignment comment (${error.message}); ` +
+                  `a 403 means the calling workflow's job needs ` +
+                  `permissions: issues: write`);
               }
             }
 
@@ -1601,10 +1680,14 @@ jobs:
               }
               if (!assignee) return;                    // no owner and no maintainer
 
-              await github.rest.issues.addAssignees({
+              const ownerAssignment = {
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: number, assignees: [assignee],
-              });
+              };
+              await actionsWrite(
+                "POST", repoApiPath(`/issues/${number}/assignees`),
+                { assignees: ownerAssignment.assignees },
+                () => github.rest.issues.addAssignees(ownerAssignment));
               console.log(`assigned ${assignee} (source ${source})`);
 
               // For a Community PR, also co-assign the original author. ProjectsV2
@@ -1618,14 +1701,19 @@ jobs:
               if (source === SOURCE_COMMUNITY && info.authorLogin &&
                   info.authorLogin.toLowerCase() !== assignee.toLowerCase()) {
                 try {
-                  await github.rest.issues.addAssignees({
+                  const authorAssignment = {
                     owner: context.repo.owner, repo: context.repo.repo,
                     issue_number: number, assignees: [info.authorLogin],
-                  });
+                  };
+                  await actionsWrite(
+                    "POST", repoApiPath(`/issues/${number}/assignees`),
+                    { assignees: authorAssignment.assignees },
+                    () => github.rest.issues.addAssignees(authorAssignment));
                   console.log(`co-assigned community author ${info.authorLogin}`);
                 } catch (error) {
                   core.warning(
-                    `could not co-assign community author ${info.authorLogin} (${error.status})`);
+                    `could not co-assign community author ${info.authorLogin} ` +
+                    `(${error.message || error.status})`);
                 }
               }
 
@@ -1634,23 +1722,32 @@ jobs:
               const toRemove =
                 info.requestedReviewers.filter(r => IGNORED.has(r.toLowerCase()));
               if (toRemove.length) {
-                await github.rest.pulls.removeRequestedReviewers({
+                const args = {
                   owner: context.repo.owner, repo: context.repo.repo,
                   pull_number: number, reviewers: toRemove,
-                });
+                };
+                await actionsWrite(
+                  "DELETE", repoApiPath(`/pulls/${number}/requested_reviewers`),
+                  { reviewers: toRemove },
+                  () => github.rest.pulls.removeRequestedReviewers(args));
               }
 
               // autoRequestedReviewer is already filtered (not author, not ignored,
               // no real existing reviewer) — request that login only.
               if (autoRequestedReviewer) {
                 try {
-                  await github.rest.pulls.requestReviewers({
+                  const args = {
                     owner: context.repo.owner, repo: context.repo.repo,
                     pull_number: number, reviewers: [autoRequestedReviewer],
-                  });
+                  };
+                  await actionsWrite(
+                    "POST", repoApiPath(`/pulls/${number}/requested_reviewers`),
+                    { reviewers: args.reviewers },
+                    () => github.rest.pulls.requestReviewers(args));
                 } catch (error) {
                   core.warning(
-                    `could not request reviewers ${autoRequestedReviewer} (${error.status})`);
+                    `could not request reviewers ${autoRequestedReviewer} ` +
+                    `(${error.message || error.status})`);
                 }
               }
 
@@ -2041,8 +2138,11 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           IGNORED_REVIEWERS: ${{ inputs.ignored_reviewers }}
+          # Compatibility fallback for cross-repo callers that have not yet
+          # granted pull-requests: write to their GITHUB_TOKEN.
+          PAT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}
         with:
-          github-token: ${{ secrets.SLANG_PR_BOT_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const ignored = (process.env.IGNORED_REVIEWERS || "")
               .split(",").map(s => s.trim().toLowerCase()).filter(Boolean);
@@ -2052,10 +2152,34 @@ jobs:
             const requested = (pr.requested_reviewers || []).map(r => r.login);
             const toRemove = requested.filter(l => ignored.includes((l || "").toLowerCase()));
             if (!toRemove.length) return;
-            await github.rest.pulls.removeRequestedReviewers({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-              reviewers: toRemove,
-            });
+            const args = {
+              owner: context.repo.owner, repo: context.repo.repo,
+              pull_number: pr.number, reviewers: toRemove,
+            };
+            try {
+              await github.rest.pulls.removeRequestedReviewers(args);
+            } catch (error) {
+              if (error.status !== 403) throw error;
+              core.warning(
+                `GITHUB_TOKEN cannot unrequest reviewers; using the PAT fallback. ` +
+                `Update the calling job's pull-requests permission.`);
+              const api = process.env.GITHUB_API_URL || "https://api.github.com";
+              const response = await fetch(
+                `${api}/repos/${context.repo.owner}/${context.repo.repo}` +
+                `/pulls/${pr.number}/requested_reviewers`,
+                {
+                  method: "DELETE",
+                  headers: {
+                    authorization: `Bearer ${process.env.PAT_TOKEN}`,
+                    accept: "application/vnd.github+json",
+                    "x-github-api-version": "2022-11-28",
+                    "content-type": "application/json",
+                  },
+                  body: JSON.stringify({ reviewers: toRemove }),
+                });
+              if (!response.ok) {
+                throw new Error(
+                  `${response.status} ${(await response.text()).slice(0, 200)}`);
+              }
+            }
             console.log(`unrequested: ${toRemove.join(", ")}`);

--- a/.github/workflows/pr-ci-complete.yml
+++ b/.github/workflows/pr-ci-complete.yml
@@ -56,6 +56,11 @@ permissions: {}
 
 jobs:
   board-sync:
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/pr-board-sync.yml
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/workflows/pr-commit-status.yml
+++ b/.github/workflows/pr-commit-status.yml
@@ -29,6 +29,11 @@ jobs:
     # (success -> recovery, failure/error -> Snagged) changes what the recompute
     # would do, and the recompute is idempotent regardless.
     if: ${{ github.event.state != 'pending' }}
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/pr-board-sync.yml
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/workflows/pr-maintenance.yml
+++ b/.github/workflows/pr-maintenance.yml
@@ -49,6 +49,11 @@ jobs:
     if: >-
       github.event_name != 'pull_request_review' ||
       github.event.pull_request.head.repo.fork == false
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/pr-board-sync.yml
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/workflows/pr-review-fork-apply.yml
+++ b/.github/workflows/pr-review-fork-apply.yml
@@ -25,6 +25,11 @@ jobs:
     # Only when the bridge completed successfully (it always should; this guards
     # against a cancelled/failed relay run).
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/pr-board-sync.yml
     secrets:
       SLANG_PR_BOT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/.github/workflows/pr-sweep-nightly.yml
+++ b/.github/workflows/pr-sweep-nightly.yml
@@ -18,6 +18,11 @@ permissions: {}
 
 jobs:
   board-sweep:
+    # Repo-scoped writes (assignees, review requests, comments) use
+    # github-actions[bot]; org-team reads and ProjectsV2 writes still use the PAT.
+    permissions:
+      issues: write
+      pull-requests: write
     uses: ./.github/workflows/pr-board-sync.yml
     with:
       mode: sweep


### PR DESCRIPTION
## Motivation

PR board sync used `SLANG_PR_BOT_TOKEN` for repo writes: assignment comments, assignees, and review requests. That token is a fine-grained PAT owned by a human. GitHub auto-subscribes whoever comments on a thread, so the PAT owner became a watcher of every PR the workflow greeted. There is no comment-API flag to skip that subscription.

## Proposed solution

Keep the PAT for what `GITHUB_TOKEN` cannot do: org team reads (Source classification) and org ProjectsV2 writes (the shared board). Route every repo-scoped write through the run's `GITHUB_TOKEN` so the visible actor is `github-actions[bot]`:

- PR and linked-issue assignees
- Community-author co-assignment
- Reviewer requests and ignored-reviewer removals
- The assignment comment

Callers grant `issues: write` and `pull-requests: write` on the calling job. The reusable workflow declares no `permissions:` block of its own: requesting more than the caller granted would fail the run at startup for every un-updated cross-repo caller.

Assignment and reviewer writes fall back to the PAT on a 403 so existing callers keep working during rollout. Comments never fall back: posting as the PAT would subscribe its owner again.

Companion caller update: [shader-slang/slangpy#1132](https://github.com/shader-slang/slangpy/pull/1132).

## Change summary

| Area | Change |
| --- | --- |
| `pr-board-sync.yml` | `actionsWrite` posts repo writes with `GITHUB_TOKEN`; PAT fallback for assignees/reviewers only |
| Caller workflows in this repo | Job-level `issues: write` + `pull-requests: write` |
| `pr-board-sync-templates/` | Same grants and docs for cross-repo copy-me callers |
| `pr-write-identity.test.js` | Covers `GITHUB_TOKEN` routing, PAT fallback, and no-fallback comments |
| `pr-board-sync.md` | Documents the identity split and caller permission contract |

## Concepts and vocabulary

- **`GITHUB_TOKEN`**: per-run Actions token; comments and assigns as `github-actions[bot]`.
- **`SLANG_PR_BOT_TOKEN`**: org-level fine-grained PAT used for org teams and ProjectsV2, and as a rollout fallback for assignment/reviewer writes.
- **Caller ceiling**: a reusable workflow's `GITHUB_TOKEN` cannot have more permission than the calling job granted.

## Process report

Consider a Community PR with no owner yet. Board sync needs to assign someone, optionally request reviewers, comment that it did so, classify Source from org team membership, and set Status on the shared ProjectsV2 board.

The last two of those are org-scoped. `GITHUB_TOKEN` has no Members or org Projects access, so they stay on the PAT. Switching them would break Source classification and the board.

The first three are repo-scoped REST writes. They used the same PAT Octokit as the org calls, which is why the comment subscribed a human. `actions/github-script` is still bound to the PAT for those org calls, so repo writes go through a raw `fetch` with `github.token` instead of that Octokit.

The reusable workflow does not declare write permissions itself. GitHub would reject un-updated callers at startup (`requesting pull-requests: write, but is only allowed none`). Inheritance plus PAT fallback for assignees/reviewers keeps board sync alive; comments are skipped until the caller grants `issues: write`.

That input shape is intentional: a caller that has not granted write yet is a valid rollout state, not a malformed request.

## Test plan

- [ ] `node .github/scripts/pr-write-identity.test.js` (and the existing assign/signal/classify tests)
- [ ] On merge, open or wait for an unassigned Community PR and confirm the assignment comment is from `github-actions[bot]`, not the PAT owner
- [ ] Confirm the PAT owner is not newly subscribed to that PR
- [ ] Confirm assignee and requested reviewer still land
- [ ] Confirm the ProjectsV2 card still gets Source/Status