### PR TITLE
Verify cooperative matrix MapElement tests on SM80

### DIFF
--- a/tools/render-test/options.cpp
+++ b/tools/render-test/options.cpp
@@ -23,20 +23,6 @@ static bool isValidFeatureName(
     DiagnosticSink* sink,
     SourceLoc loc)
 {
-    // WAR: Accept cooperative-matrix-2 sub-features until RHI backend supports them
-    // These features will be gracefully skipped at runtime if hardware doesn't support them
-    if (featureName.startsWith("cooperative-matrix-"))
-    {
-        if (sink)
-        {
-            sink->diagnoseRaw(
-                Severity::Warning,
-                "Using cooperative-matrix-2 feature that is not yet fully supported "
-                "in RHI backend. "
-                "Test will be skipped if hardware doesn't support it.");
-        }
-        return true;
-    }
 #define SLANG_RHI_FEATURES_X(id, name) name,
     static const char* kValidFeatureNames[] = {SLANG_RHI_FEATURES(SLANG_RHI_FEATURES_X)};
 #undef SLANG_RHI_FEATURES_X


### PR DESCRIPTION
> [!IMPORTANT]
> Verification PR only. Do not merge while shader-slang/slang-rhi#851 is unmerged.

## Motivation

The ten Vulkan runtime cases in `map-element-single.slang` and `map-element-tuple.slang` are active, but they are currently ignored even on the SM80Plus runner. Their `-render-feature cooperative-matrix-per-element-operations` requirement cannot be resolved or reported by the slang-rhi revision currently pinned in Slang.

This PR checks whether the granular cooperative-matrix-2 feature reporting from shader-slang/slang-rhi#851 makes those tests execute successfully on the Linux SM80Plus CI runner.

## Proposed solution

Temporarily pin `external/slang-rhi` to the exact head commit of shader-slang/slang-rhi#851, `339f23472d2bc7ebef1f51574ec467e34aebbabc`. Remove render-test's wildcard acceptance of `cooperative-matrix-*` names so the test directives must resolve through the real `SLANG_RHI_FEATURES` entry.

No MapElement test directive needs changing: all ten cases already request the exact new feature name.

The dependency change registers all five granular cooperative-matrix-2 operation names. Consequently, the other cooperative-matrix tests that use those names also stop relying on the wildcard and are gated by their corresponding Vulkan feature bits; that wider effect is intentional for this verification.

## Change summary

- Update the slang-rhi gitlink to `339f23472d2bc7ebef1f51574ec467e34aebbabc`.
- Remove the temporary cooperative-matrix feature-name validation workaround from `tools/render-test/options.cpp`.
- Leave the five single-matrix and five tuple MapElement test modes unchanged.

## Concepts and vocabulary

- **Render feature** — a runtime device requirement attached to a test directive; an unsupported feature causes the test to be ignored rather than dispatched.
- **Granular cooperative-matrix-2 feature** — one independently reported Vulkan feature bit, in this case `cooperativeMatrixPerElementOperations`.
- **Gitlink** — the commit recorded by the parent Slang repository for its slang-rhi submodule.

## Process report

`Options::parse` first validates `-render-feature` names against `SLANG_RHI_FEATURES`. The previous slang-rhi revision lacked the per-element name, so `options.cpp` temporarily accepted every `cooperative-matrix-*` prefix. Later, render-test mapped the name back through the same feature list; because there was still no matching enum entry, the requirement became unavailable and the test was ignored.

The pinned slang-rhi commit adds `cooperative-matrix-per-element-operations` to the feature list and reports it only when Vulkan returns `cooperativeMatrixPerElementOperations == VK_TRUE`. The name can therefore pass normal validation, map to `Feature::CooperativeMatrixPerElementOperations`, and reach dispatch on a supporting device. Removing the wildcard workaround ensures this verification exercises that real path rather than continuing to accept an unresolved spelling.

Local end-to-end verification used Vulkan on an NVIDIA RTX PRO 6000 Blackwell Workstation Edition with SPIR-V validation enabled. All five modes in each MapElement file ran as real tests: `100% of tests passed (10/10)`, with no corresponding `ignored test:` entries.

The [SM80Plus CI job](https://github.com/shader-slang/slang/actions/runs/33684887674/job/100438159342) passed on an NVIDIA L4 runner with the corrected slang-rhi head pinned by this PR. Its log shows all ten MapElement Vulkan variants as `passed test:` rather than `ignored test:`; the exact MapElement tally is 10 passed, 0 ignored, 0 failed, and the complete selected suite passed 412/412. This PR tracks the Slang side of #9030 and is intentionally not intended for merge before the slang-rhi dependency lands.
