### PR TITLE
Codify declarative, proportionate comment style in agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,6 +84,16 @@ change.)
 - **Comment functions as complete sentences: what, then why.** Say what the function does first;
   then, if non-obvious, why it exists. Include a concrete example for non-trivial behavior; avoid
   terse fragment/bullet-only function comments.
+- **Write comments as declarative statements, not imperatives.** State how the code is structured
+  and why, in the present tense ("We split X into Y because Z"), not as an instruction ("Keep X in
+  Y") — imperative phrasing tends to state what without why. Don't open a paragraph with an
+  unattached "This."
+- **Keep comments proportionate; land on a conclusion.** A comment records durable state — an
+  invariant, a constraint, an unusual shape — not the edits or review rounds that produced it (a
+  renumbering note belongs in the commit message). Prefer one "if X, then Y, because Z" sentence
+  over a paragraph of premises with no stated point. If justifying one line takes several
+  paragraphs, restructure the code instead — extract a named helper, assert the invariant, simplify
+  the condition.
 - **Reuse before you write; then extract.** Before adding a helper, check shared headers
   (`slang-ast-type.h`, `slang-ir-util.h`, the `*-util.h` files) for an existing one (e.g.
   `isDeclRefTypeOf<T>`). When the logic is genuinely new, extract it into a named, documented helper

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -93,7 +93,8 @@ change.)
   renumbering note belongs in the commit message). Prefer one "if X, then Y, because Z" sentence
   over a paragraph of premises with no stated point. If justifying one line takes several
   paragraphs, restructure the code instead — extract a named helper, assert the invariant, simplify
-  the condition.
+  the condition. This is about ordinary comments; a genuinely subtle cross-pass invariant can still
+  warrant a fuller worked example — that is the exception, not the default.
 - **Reuse before you write; then extract.** Before adding a helper, check shared headers
   (`slang-ast-type.h`, `slang-ir-util.h`, the `*-util.h` files) for an existing one (e.g.
   `isDeclRefTypeOf<T>`). When the logic is genuinely new, extract it into a named, documented helper

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,35 @@ change.)
   newElementType, `vector<T,N>` → `vector<newElementType,N>`, `matrix<T,R,C>` → `matrix<newElementType,R,C>`."_
   — not _"element coerce target"_.
 
+- **Write comments as declarative statements about the design, not imperatives directed at the
+  reader.** State how the code is structured and why, in the present tense ("We split X into Y
+  because Z"), not as an instruction to whoever is reading it ("Keep X in Y"). Prefer:
+
+  > _"We have split support for automatic differentiation into a supplement that loads as a
+  > separate module, in order to improve compile times for code that doesn't need it. Existing
+  > Slang code may assume autodiff support is pervasively available, so we place the relevant
+  > public declarations and attributes here in the core module rather than the supplement; user
+  > code that refers to these attributes triggers on-demand loading of the autodiff supplement."_
+
+  over:
+
+  > _"Keep the custom-derivative attribute spellings in the base module. Semantic checking uses a
+  > recognized attribute as the signal to load the full autodiff module before validating it."_
+
+  An imperative comment tends to state only _what_ to do and skip _why_ the structure exists;
+  declarative "we" phrasing makes the why unavoidable. Give a paragraph an explicit subject
+  instead of opening with an unattached "This."
+
+- **Keep comments proportionate to what they explain, and land on a conclusion.** A comment
+  records durable state — an invariant, a constraint, the reason for an unusual shape — not the
+  edits or review rounds that produced it (a renumbering note belongs in the commit message, not
+  the header). Prefer one "if X, then Y, because Z" sentence over a paragraph of premises that
+  never states its point. If justifying a single conditional or a single line takes several
+  paragraphs, treat that as a signal to restructure the code — extract a named helper, assert the
+  invariant, simplify the condition — rather than a signal to add more prose. This is about
+  ordinary comments; a genuinely subtle cross-pass invariant can still warrant the fuller worked
+  example below, but that is the exception, not the default.
+
 - **Use conversational examples for code comments and PR explanations.** When explaining a subtle
   compiler path, prefer "Consider this example:" followed by the relevant user code. Do not use
   abstract labels such as "Full source shape", "AST trace", or "IR trace" as a substitute for


### PR DESCRIPTION
## Motivation

PR #12136's human review repeatedly flagged agent-authored comments for the same two problems:

- **Imperative phrasing that skips the why.** E.g. `// Keep the custom-derivative attribute spellings in the base module. Semantic checking uses a recognized attribute as the signal to load the full autodiff module before validating it.` reads as an instruction to the reader rather than an explanation of the design, and states *what* without explaining *why* the attributes live where they do.
- **Wall-of-text justification that never states its point**, or that narrates the PR's own edit history (e.g. an enum comment explaining which numeric slots a previous rebase claimed) instead of the durable rule a future reader needs.

The reviewer's own suggested rewrites were short, declarative "we" statements that state a conclusion instead of listing premises — see the review thread on `source/slang/core.meta.slang` and `include/slang.h` in #12136 for the concrete before/after.

## Change summary

Adds two rules to the "Code Style and Review Conventions" section of both `CLAUDE.md` (canonical) and `.github/copilot-instructions.md` (condensed mirror), using the review's own example:

- Write comments as declarative statements about the design, not imperatives directed at the reader.
- Keep comments proportionate to what they explain, and land on a conclusion instead of a paragraph of hedges.

## Process report

This is an instructions-only change (no code, no tests). The two new bullets are placed next to the existing "write function comments as complete sentences: what, then why" rule, since they govern the same surface (comment tone), and a clarifying note ties them to the existing "use conversational examples for subtle compiler paths" bullet so the two don't read as contradictory — ordinary comments should stay short and declarative, while a genuinely subtle cross-pass invariant can still warrant the fuller worked-example treatment that bullet already describes.