### PR TITLE
Fix HostVM vector-scalar broadcast and composite extraction

### DIFF
--- a/docs/generated/tests/_meta/expected-failures.txt
+++ b/docs/generated/tests/_meta/expected-failures.txt
@@ -57,24 +57,11 @@ docs/generated/tests/conformance/expressions-literal/bool-true-false.slang
 # language-reference/expressions-operators bundle.
 docs/generated/tests/conformance/expressions-operators/conditional-does-not-short-circuit.slang
 
-# Pending: docs/generated/tests/_meta/findings/slangi-vm-vector-scalar-binary-op-wrong-values.yaml
-# slangi VM computes `int4(1,2,3,4) - 1` as `int4(0,0,0,0)` instead
-# of `int4(0,1,2,3)`. Vector-scalar binary op broadcast appears
-# missing in the VM emitter. (Will become a tracking issue after
-# human triage.)
-docs/generated/tests/conformance/types-vector-and-matrix/vector-binary-scalar-broadcast.slang
-
 # Pending: docs/generated/tests/_meta/findings/slangi-vm-swizzle-assign-bytecode-unimplemented.yaml
 # slangi VM aborts with "unimplemented: VM bytecode gen for inst"
 # when compiling a vector swizzle-assign (v.xz = int2(...)). The
 # doc shows this as a supported construct.
 docs/generated/tests/conformance/types-vector-and-matrix/vector-swizzle-assign.slang
-
-# Pending: docs/generated/tests/_meta/findings/slangi-vm-matrix-mij-swizzle-working-set-oob.yaml
-# slangi VM triggers "operand access out of bounds in working set
-# section" when reading a matrix element via `_mij` swizzle. Doc
-# lists this as supported.
-docs/generated/tests/conformance/expressions-member-access/matrix-mij-zero-based.slang
 
 # Pending: docs/generated/tests/_meta/findings/slangi-vm-global-var-bytecode-unsupported.yaml
 # slangi VM aborts with "unsupported global inst for vm bytecode

--- a/source/slang/slang-emit-vm.cpp
+++ b/source/slang/slang-emit-vm.cpp
@@ -984,6 +984,12 @@ public:
 
                 auto baseOperand = ensureInst(base);
                 baseOperand.offset += (uint32_t)offset;
+                IRSizeAndAlignment fieldSizeAlignment = {};
+                getNaturalSizeAndAlignment(
+                    codeGenContext->getTargetReq(),
+                    field->getFieldType(),
+                    &fieldSizeAlignment);
+                baseOperand.size = (uint32_t)fieldSizeAlignment.size;
                 mapInstToOperand[inst] = baseOperand;
             }
             break;
@@ -1003,6 +1009,7 @@ public:
                 if (as<IRIntLit>(index))
                 {
                     baseOperand.offset += (uint32_t)(stride * getIntVal(index));
+                    baseOperand.size = (uint32_t)sizeAlignment.size;
                     mapInstToOperand[inst] = baseOperand;
                     break;
                 }

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1779,8 +1779,8 @@ Result linkAndOptimizeIR(
     if (sink->getErrorCount() != 0)
         return SLANG_FAIL;
 
-    // Don't need to run any further target-dependent passes if we are generating code
-    // for host vm.
+    // HostVM skips the later target pipelines, but its bytecode arithmetic derives one source size
+    // from operand zero's element width and lane count. Make scalar broadcasts explicit first.
     if (target == CodeGenTarget::HostVM)
     {
         SLANG_PASS(performForceInlining);
@@ -1788,6 +1788,7 @@ Result linkAndOptimizeIR(
         // bytecode constants section cannot represent void values. Remove them before emission,
         // as the later target pipelines do.
         SLANG_PASS(cleanUpVoidType);
+        SLANG_PASS(legalizeScalarOperandsOfBinaryOps);
         SLANG_PASS(simplifyIR, targetProgram, defaultIRSimplificationOptions, sink);
         return SLANG_OK;
     }

--- a/source/slang/slang-ir-legalize-binary-operator.cpp
+++ b/source/slang/slang-ir-legalize-binary-operator.cpp
@@ -19,6 +19,35 @@ static bool isVectorOrMatrix(IRType* type)
     }
 };
 
+/// Return the element type of a vector or matrix.
+static IRType* getVectorOrMatrixElementType(IRType* type)
+{
+    if (auto vectorType = as<IRVectorType>(type))
+        return vectorType->getElementType();
+
+    auto matrixType = as<IRMatrixType>(type);
+    SLANG_ASSERT(matrixType);
+    return matrixType->getElementType();
+}
+
+/// Return a vector or matrix with the same shape and a new element type.
+static IRType* replaceVectorOrMatrixElementType(
+    IRBuilder& builder,
+    IRType* type,
+    IRType* elementType)
+{
+    if (auto vectorType = as<IRVectorType>(type))
+        return builder.getVectorType(elementType, vectorType->getElementCount());
+
+    auto matrixType = as<IRMatrixType>(type);
+    SLANG_ASSERT(matrixType);
+    return builder.getMatrixType(
+        elementType,
+        matrixType->getRowCount(),
+        matrixType->getColumnCount(),
+        matrixType->getLayout());
+}
+
 static bool isDivisionByMatrix(IRInst* inst)
 {
     return (inst->getOp() == kIROp_Div) && (as<IRMatrixType>(inst->getOperand(1)->getDataType()));
@@ -32,7 +61,9 @@ static bool isMatrixDividedByScalar(IRInst* inst)
 
 // If one operand is a composite type (vector or matrix), and the other one is a scalar
 // type, then the scalar is converted to a composite type.
-static void legalizeScalarOperandsToMatchComposite(IRInst* inst)
+static void legalizeScalarOperandsToMatchComposite(
+    IRInst* inst,
+    bool preserveShiftOperandElementType)
 {
     if (isVectorOrMatrix(inst->getOperand(0)->getDataType()) &&
         as<IRBasicType>(inst->getOperand(1)->getDataType()))
@@ -41,12 +72,22 @@ static void legalizeScalarOperandsToMatchComposite(IRInst* inst)
         builder.setInsertBefore(inst);
         IRType* compositeType = inst->getOperand(0)->getDataType();
         IRInst* scalarValue = inst->getOperand(1);
-        // Retain the scalar type for shifts
+        // WGSL and Metal retain the shift amount's element type. HostVM instead derives one
+        // element width from the left operand and uses it for both operands.
         if (inst->getOp() == kIROp_Lsh || inst->getOp() == kIROp_Rsh)
         {
-            auto vectorType = as<IRVectorType>(compositeType);
-            compositeType =
-                builder.getVectorType(scalarValue->getDataType(), vectorType->getElementCount());
+            if (preserveShiftOperandElementType)
+            {
+                compositeType = replaceVectorOrMatrixElementType(
+                    builder,
+                    compositeType,
+                    scalarValue->getDataType());
+            }
+            else
+            {
+                IRType* elementType = getVectorOrMatrixElementType(compositeType);
+                scalarValue = builder.emitCast(elementType, scalarValue);
+            }
         }
         auto newRhs = builder.emitMakeCompositeFromScalar(compositeType, scalarValue);
         builder.replaceOperand(inst->getOperands() + 1, newRhs);
@@ -59,16 +100,63 @@ static void legalizeScalarOperandsToMatchComposite(IRInst* inst)
         builder.setInsertBefore(inst);
         IRType* compositeType = inst->getOperand(1)->getDataType();
         IRInst* scalarValue = inst->getOperand(0);
-        // Retain the scalar type for shifts
+        // WGSL and Metal retain the shift amount's element type. HostVM instead derives one
+        // element width from the right operand and uses it for both operands.
         if (inst->getOp() == kIROp_Lsh || inst->getOp() == kIROp_Rsh)
         {
-            auto vectorType = as<IRVectorType>(compositeType);
-            compositeType =
-                builder.getVectorType(scalarValue->getDataType(), vectorType->getElementCount());
+            if (preserveShiftOperandElementType)
+            {
+                compositeType = replaceVectorOrMatrixElementType(
+                    builder,
+                    compositeType,
+                    scalarValue->getDataType());
+            }
+            else
+            {
+                IRType* elementType = getVectorOrMatrixElementType(compositeType);
+                scalarValue = builder.emitCast(elementType, scalarValue);
+            }
         }
         auto newLhs = builder.emitMakeCompositeFromScalar(compositeType, scalarValue);
         builder.replaceOperand(inst->getOperands(), newLhs);
     }
+}
+
+static void legalizeScalarOperandsOfBinaryOpsRec(IRInst* inst)
+{
+    switch (inst->getOp())
+    {
+    case kIROp_Add:
+    case kIROp_Sub:
+    case kIROp_Mul:
+    case kIROp_Div:
+    case kIROp_FRem:
+    case kIROp_IRem:
+    case kIROp_And:
+    case kIROp_Or:
+    case kIROp_BitAnd:
+    case kIROp_BitOr:
+    case kIROp_BitXor:
+    case kIROp_Lsh:
+    case kIROp_Rsh:
+    case kIROp_Eql:
+    case kIROp_Neq:
+    case kIROp_Greater:
+    case kIROp_Less:
+    case kIROp_Geq:
+    case kIROp_Leq:
+        legalizeScalarOperandsToMatchComposite(inst, false);
+        break;
+    default:
+        for (auto child : inst->getModifiableChildren())
+            legalizeScalarOperandsOfBinaryOpsRec(child);
+        break;
+    }
+}
+
+void legalizeScalarOperandsOfBinaryOps(IRModule* module)
+{
+    legalizeScalarOperandsOfBinaryOpsRec(module->getModuleInst());
 }
 
 // Replaces a division by scalar operation by a multiplication.
@@ -140,7 +228,7 @@ void legalizeBinaryOp(IRInst* inst, DiagnosticSink* sink, TargetProgram* targetP
     // type. Division by matrix is not supported on Metal and WGSL.
     if (!isMatrixDividedByScalar(inst))
     {
-        legalizeScalarOperandsToMatchComposite(inst);
+        legalizeScalarOperandsToMatchComposite(inst, true);
     }
     else if (isWGPUTarget(targetProgram->getTargetReq()->getTarget()))
     {

--- a/source/slang/slang-ir-legalize-binary-operator.h
+++ b/source/slang/slang-ir-legalize-binary-operator.h
@@ -18,6 +18,13 @@ class DiagnosticSink;
 //   signed operand is converted to unsigned.
 void legalizeBinaryOp(IRInst* inst, DiagnosticSink* sink, TargetProgram* targetProgram);
 
+/// Convert scalar operands of composite binary operations into matching vectors or matrices.
+///
+/// HostVM bytecode derives one source size from operand zero's element width and lane count, so
+/// every operand must match both properties. This pass represents implicit scalar broadcasts
+/// explicitly with `makeVectorFromScalar` or `makeMatrixFromScalar`.
+void legalizeScalarOperandsOfBinaryOps(IRModule* module);
+
 // The logical binary operators such as AND and OR takes boolean types are its input.
 // If they are in integer type, as an example, we need to explicitly cast to bool type.
 // Also the return type from the logical operators should be a boolean type.

--- a/tests/byte-code/composite-extract-operand-size.slang
+++ b/tests/byte-code/composite-extract-operand-size.slang
@@ -1,0 +1,38 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+struct Result
+{
+    float3 value;
+    bool valid;
+    int a;
+    int b;
+    int c;
+}
+
+[noinline]
+Result makeResult(int seed)
+{
+    Result result;
+    result.value = float3(1.0, 2.0, 3.0);
+    result.valid = true;
+    result.a = seed + 3;
+    result.b = seed + 4;
+    result.c = seed + 5;
+    return result;
+}
+
+[noinline]
+void printLastElement(float4 value)
+{
+    printf("%.1f\n", value[3]);
+}
+
+export __extern_cpp int main(int argc, Ptr<NativeString> argv)
+{
+    Result result = makeResult(argc);
+    //CHECK: 6
+    printf("%d\n", result.c);
+    //CHECK: 4.0
+    printLastElement(float4(1.0, 2.0, 3.0, 4.0));
+    return 0;
+}

--- a/tests/byte-code/vector-scalar-broadcast.slang
+++ b/tests/byte-code/vector-scalar-broadcast.slang
@@ -1,0 +1,84 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+float3 divide(float3 value, float divisor)
+{
+    return value / divisor;
+}
+
+int4 subtract(int4 value, int amount)
+{
+    return value - amount;
+}
+
+int4 reverseSubtract(int amount, int4 value)
+{
+    return amount - value;
+}
+
+uint16_t4 shiftLeft(uint16_t4 value, int amount)
+{
+    return value << amount;
+}
+
+bool4 greaterThan(int4 value, int threshold)
+{
+    return value > threshold;
+}
+
+float2x2 scale(float2x2 value, float amount)
+{
+    return value * amount;
+}
+
+export __extern_cpp int main()
+{
+    float3 quotient = divide(float3(126.0, 128.0, 128.0), 255.0);
+    //CHECK: quotient: 0.494118 0.501961 0.501961
+    printf("quotient: %.6f %.6f %.6f\n", quotient.x, quotient.y, quotient.z);
+
+    int4 difference = subtract(int4(1, 2, 3, 4), 1);
+    //CHECK: difference: 0 1 2 3
+    printf(
+        "difference: %d %d %d %d\n",
+        difference.x,
+        difference.y,
+        difference.z,
+        difference.w);
+
+    int4 reverseDifference = reverseSubtract(4, int4(1, 2, 3, 4));
+    //CHECK: reverse: 3 2 1 0
+    printf(
+        "reverse: %d %d %d %d\n",
+        reverseDifference.x,
+        reverseDifference.y,
+        reverseDifference.z,
+        reverseDifference.w);
+
+    uint16_t4 shifted = shiftLeft(uint16_t4(1, 2, 3, 4), 1);
+    //CHECK: shifted: 2 4 6 8
+    printf(
+        "shifted: %d %d %d %d\n",
+        int(shifted.x),
+        int(shifted.y),
+        int(shifted.z),
+        int(shifted.w));
+
+    bool4 comparison = greaterThan(int4(1, 2, 3, 4), 2);
+    //CHECK: comparison: 0 0 1 1
+    printf(
+        "comparison: %d %d %d %d\n",
+        int(comparison.x),
+        int(comparison.y),
+        int(comparison.z),
+        int(comparison.w));
+
+    float2x2 scaled = scale(float2x2(1.0, 2.0, 3.0, 4.0), 2.0);
+    //CHECK: scaled: 2.0 4.0 6.0 8.0
+    printf(
+        "scaled: %.1f %.1f %.1f %.1f\n",
+        scaled[0][0],
+        scaled[0][1],
+        scaled[1][0],
+        scaled[1][1]);
+    return 0;
+}

--- a/tests/metal/matrix-shift-scalar-legalize.slang
+++ b/tests/metal/matrix-shift-scalar-legalize.slang
@@ -1,0 +1,19 @@
+//TEST:SIMPLE(filecheck=CHECK):-target metal -stage compute -entry computeMain
+
+RWStructuredBuffer<uint> output;
+
+// A narrow matrix shifted by a wider scalar used to crash binary-op legalization because it
+// assumed that every composite shift operand was a vector.
+[noinline]
+matrix<uint16_t, 2, 2> shiftMatrix(matrix<uint16_t, 2, 2> value, uint amount)
+{
+    return value << amount;
+}
+
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    matrix<uint16_t, 2, 2> value = {1, 2, 3, 4};
+    //CHECK: << matrix<uint,int(2),int(2)>
+    output[0] = uint(shiftMatrix(value, 1)[0][0]);
+}


### PR DESCRIPTION
## Motivation

`slangi` (HostVM) mishandles language-level scalar broadcast and some composite projections.

Consider:

```slang
float3 ycbcr = float3(126.0, 128.0, 128.0) / 255.0;
printf("%.6f %.6f %.6f\n", ycbcr.x, ycbcr.y, ycbcr.z);
```

The frontend type-checks this as vector/scalar arithmetic, but HostVM bytecode emission never inserts `MakeVectorFromScalar`. The interpreter then treats both `Div` operands as `float3` lanes: lane 0 is correct, lanes 1–2 read past the 4-byte scalar. That produces garbage or `VM operand access out of bounds in working set section`.

A second, independent failure shows up when printing a struct field near the end of a composite, or when reading `v[3]` / a matrix `_mij` swizzle. `FieldExtract` and constant-index `GetElement` alias the base operand, advance `offset`, and leave `.size` equal to the whole aggregate. `Print` and other non-Call ops then validate that stale size.

These are already recorded as expected interpreter failures:

- `docs/generated/tests/conformance/types-vector-and-matrix/vector-binary-scalar-broadcast.slang`
- `docs/generated/tests/conformance/expressions-member-access/matrix-mij-zero-based.slang`

This is not #12496 / #12509. That change clamped `VMOp::Call` copies to `min(slotStride, operand.size)` for autodiff argument padding. It does not legalize scalar broadcasts, and it does not narrow projected field/element operand sizes at the emitter.

## Proposed solution

Canonicalize HostVM IR the same way Metal and WGSL already do: walk binary ops and convert a scalar operand into a matching vector or matrix with `makeVectorFromScalar` / `makeMatrixFromScalar` before bytecode emission.

HostVM then derives one source size from operand 0's element width and lane count, so both operands of a shift must match the left-hand element type. The shared helper therefore takes an explicit `preserveShiftOperandElementType` flag: Metal/WGSL keep the shift amount's own type; HostVM casts the amount to the composite element type first.

Separately, when the VM emitter aliases a composite for `FieldExtract` or constant-index `GetElement`, set `operand.size` to the field's or element's natural size (not stride). Registers are allocated by `.size`; spacing uses stride.

## Change summary

| File | Change |
| --- | --- |
| `source/slang/slang-ir-legalize-binary-operator.{h,cpp}` | Add `legalizeScalarOperandsOfBinaryOps`; split shift broadcast by target contract; handle matrix composites without assuming a vector. |
| `source/slang/slang-emit.cpp` | Run that pass on the HostVM early-return path, after force-inlining and void cleanup, before `simplifyIR`. |
| `source/slang/slang-emit-vm.cpp` | Narrow `FieldExtract` and constant-index `GetElement` operand sizes to the projected value. |
| `tests/byte-code/vector-scalar-broadcast.slang` | Cover `float3 / scalar`, both orders of `int4 - scalar`, `uint16_t4 << int`, `bool4` comparison, and `float2x2 * scalar`. |
| `tests/byte-code/composite-extract-operand-size.slang` | Cover trailing struct-field extract and constant-index `float4[3]`. |
| `tests/metal/matrix-shift-scalar-legalize.slang` | Cover `matrix<uint16_t,2,2> << uint` on Metal (the previous vector-only shift path crashed). |
| `docs/generated/tests/_meta/expected-failures.txt` | Remove the two now-passing interpreter entries. |

## Concepts and vocabulary

- **HostVM** — the `slangi` bytecode target (`CodeGenTarget::HostVM`). Its arithmetic ops take one `ArithmeticExtCode` from operand 0 and apply that lane count and element width to both sources.
- **Scalar broadcast** — the language rule that `vector OP scalar` (and the reverse) has the vector result type. Other targets either emit source that a downstream compiler understands or insert `MakeVectorFromScalar`; HostVM previously did neither.
- **Operand `.size` vs stride** — `.size` is the byte extent reserved for a value in the working set. Array/vector elements are *spaced* by `getStride()`, but each element *occupies* `.size`. Projected fields must record `.size`, not stride.

## Process report

**HostVM scalar broadcast.** `linkAndOptimizeIR()` returned early for HostVM before any binary-op legalization. Lowering emits `kIROp_Div` (and siblings) with heterogeneous operand types. Metal/WGSL call `legalizeBinaryOp` → `legalizeScalarOperandsToMatchComposite`; HostVM skipped that. The new module walk calls the same helper with `preserveShiftOperandElementType = false`, so `float3 / 255.0` becomes `Div(vec3, MakeVectorFromScalar(vec3, 255.0))`. That shape is valid IR for HostVM: the VM already implements same-sized vector arithmetic and `kIROp_MakeVectorFromScalar`. Teaching the interpreter to guess scalar operands would duplicate language rules and hide malformed IR.

**Narrow-width shifts.** Reusing the Metal/WGSL helper unchanged would keep `uint16_t4 << 1` as `Lsh(vec<uint16,4>, vec<int,4>)`. HostVM still sizes both sources from operand 0 (8 bytes), so it would reread the 16-byte amount as four `uint16` values `{1,0,1,0}`. The HostVM path therefore casts the scalar to the composite element type before broadcasting. Metal/WGSL still preserve the shift amount's type. `int4 << int` is a no-op cast because the types already match.

**Matrix shift legalization.** The old shift branch did `as<IRVectorType>(compositeType)->getElementCount()`. A matrix composite made that null. `replaceVectorOrMatrixElementType` now preserves vector or matrix shape. `tests/metal/matrix-shift-scalar-legalize.slang` covers `matrix<uint16_t,2,2> << uint`, which previously SIGSEGV'd on Metal.

**FieldExtract / GetElement operand size.** The emitter already computed field offset and element stride. It stored the aliased operand without updating `.size`, so a trailing `int` in a 28-byte struct still claimed 28 bytes and failed `Print` validation. The producer of the alias is the right layer: `Print` and arithmetic ops correctly use the recorded size. Use `fieldSizeAlignment.size` / `sizeAlignment.size`, not stride, because `allocReg` and natural struct layout accumulate `.size`. Constant-index `GetElement` still uses stride for the offset step.

**Input-shape check.** `Div(vec3, float)` is valid for HLSL emit and invalid for HostVM; the HostVM producer must canonicalize it. A projected field or element with the aggregate's byte extent is not a valid VM operand; the emitter that creates the alias must narrow it. `BitCast` is unchanged: it is not a projection, and `bit_cast` requires equal source and destination sizes.

**Tests that fail without the change.** `vector-scalar-broadcast.slang` and `vector-binary-scalar-broadcast.slang` fail without HostVM legalization. `composite-extract-operand-size.slang` and `matrix-mij-zero-based.slang` fail without the emitter size narrowing. The Metal matrix-shift test fails (crash) without the vector/matrix shift helper.

## Test plan

- [x] `slang-test tests/byte-code/vector-scalar-broadcast.slang`
- [x] `slang-test tests/byte-code/composite-extract-operand-size.slang`
- [x] `slang-test tests/byte-code/composite.slang`
- [x] `slang-test tests/metal/matrix-shift-scalar-legalize.slang`
- [x] `slang-test docs/generated/tests/conformance/types-vector-and-matrix/vector-binary-scalar-broadcast.slang`
- [x] `slang-test docs/generated/tests/conformance/expressions-member-access/matrix-mij-zero-based.slang`