### PR TITLE
Use shared Falcor bridge runner label

### DIFF
--- a/.github/workflows/ci-falcor2-perf-bridge-smoke.yml
+++ b/.github/workflows/ci-falcor2-perf-bridge-smoke.yml
@@ -15,7 +15,7 @@ jobs:
   falcor2-perf-bridge-smoke:
     name: Falcor 2 perf bridge smoke
     timeout-minutes: 30
-    runs-on: [Linux, self-hosted, X64, falcor2-perf-bridge]
+    runs-on: [Linux, self-hosted, X64, falcor-bridge]
     # Keep this public workflow thin, matching ci-falcor-test.yml.
     defaults:
       run:


### PR DESCRIPTION
Switch the Falcor 2 perf bridge smoke workflow to the shared Falcor bridge runner label. Tested with a manual workflow dispatch on this branch: https://github.com/shader-slang/slang/actions/runs/33867480242