### PR TITLE
Post skipped SlangPy status for docs-only PRs

### DIFF
--- a/.github/workflows/ci-slangpy-trigger-test.yml
+++ b/.github/workflows/ci-slangpy-trigger-test.yml
@@ -84,12 +84,14 @@ jobs:
           PR_HEAD_REPO=$(echo "$PR_JSON" | jq -r '.head.repo.full_name')
           PR_TITLE=$(echo "$PR_JSON" | jq -r '.title' | head -1 | cut -c1-80)
           PR_AUTHOR=$(echo "$PR_JSON" | jq -r '.user.login')
-          echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
-          echo "sha=$PR_SHA" >> "$GITHUB_OUTPUT"
-          echo "is_fork_pr=$PR_IS_FORK" >> "$GITHUB_OUTPUT"
-          echo "head_repo=$PR_HEAD_REPO" >> "$GITHUB_OUTPUT"
-          echo "title=$PR_TITLE" >> "$GITHUB_OUTPUT"
-          echo "author=$PR_AUTHOR" >> "$GITHUB_OUTPUT"
+          {
+            echo "number=${{ inputs.pr_number }}"
+            echo "sha=$PR_SHA"
+            echo "is_fork_pr=$PR_IS_FORK"
+            echo "head_repo=$PR_HEAD_REPO"
+            echo "title=$PR_TITLE"
+            echo "author=$PR_AUTHOR"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Get PR info (automatic trigger)
         if: github.event_name == 'pull_request_target'
@@ -97,13 +99,15 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
-          echo "is_fork_pr=${{ github.event.pull_request.head.repo.fork }}" >> "$GITHUB_OUTPUT"
-          echo "head_repo=${{ github.event.pull_request.head.repo.full_name }}" >> "$GITHUB_OUTPUT"
-          # Use first line only; truncate to keep run-name readable
-          echo "title=$(echo "$PR_TITLE" | head -1 | cut -c1-80)" >> "$GITHUB_OUTPUT"
-          echo "author=${{ github.event.pull_request.user.login }}" >> "$GITHUB_OUTPUT"
+          {
+            echo "number=${{ github.event.pull_request.number }}"
+            echo "sha=${{ github.event.pull_request.head.sha }}"
+            echo "is_fork_pr=${{ github.event.pull_request.head.repo.fork }}"
+            echo "head_repo=${{ github.event.pull_request.head.repo.full_name }}"
+            # Use first line only; truncate to keep run-name readable
+            echo "title=$(echo "$PR_TITLE" | head -1 | cut -c1-80)"
+            echo "author=${{ github.event.pull_request.user.login }}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Get PR info (merge queue)
         if: github.event_name == 'merge_group'
@@ -113,17 +117,21 @@ jobs:
         run: |
           QUEUE_REF="${{ github.event.merge_group.head_ref || github.ref_name }}"
           PR_NUMBER=$(echo "$QUEUE_REF" | sed -n 's|.*/pr-\([0-9]*\)-.*|\1|p')
-          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "sha=${{ github.event.merge_group.head_sha || github.sha }}" >> "$GITHUB_OUTPUT"
-          echo "ref=$QUEUE_REF" >> "$GITHUB_OUTPUT"
-          echo "checkout_mode=ref" >> "$GITHUB_OUTPUT"
-          echo "checkout_repo=${{ github.repository }}" >> "$GITHUB_OUTPUT"
-          echo "is_fork_pr=false" >> "$GITHUB_OUTPUT"
-          echo "head_repo=${{ github.repository }}" >> "$GITHUB_OUTPUT"
+          {
+            echo "number=$PR_NUMBER"
+            echo "sha=${{ github.event.merge_group.head_sha || github.sha }}"
+            echo "ref=$QUEUE_REF"
+            echo "checkout_mode=ref"
+            echo "checkout_repo=${{ github.repository }}"
+            echo "is_fork_pr=false"
+            echo "head_repo=${{ github.repository }}"
+          } >> "$GITHUB_OUTPUT"
           if [ -n "$PR_NUMBER" ]; then
             PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER")
-            echo "title=$(echo "$PR_JSON" | jq -r '.title' | head -1 | cut -c1-80)" >> "$GITHUB_OUTPUT"
-            echo "author=$(echo "$PR_JSON" | jq -r '.user.login')" >> "$GITHUB_OUTPUT"
+            {
+              echo "title=$(echo "$PR_JSON" | jq -r '.title' | head -1 | cut -c1-80)"
+              echo "author=$(echo "$PR_JSON" | jq -r '.user.login')"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Post pending status
@@ -163,4 +171,42 @@ jobs:
                 slang_pr_title: process.env.PR_TITLE || '',
                 slang_pr_author: `${{ steps.pr_auto.outputs.author || steps.pr_manual.outputs.author || steps.pr_mq.outputs.author }}`
               }
+            });
+
+  mark-slangpy-tests-skipped:
+    needs: [filter]
+    runs-on: ubuntu-latest
+    if: needs.filter.outputs.should-run == 'false'
+
+    steps:
+      - name: Post skipped status
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        with:
+          script: |
+            const prNumber = Number.parseInt(process.env.PR_NUMBER || '', 10);
+            let sha = context.payload.pull_request?.head?.sha;
+
+            if (!sha) {
+              if (!Number.isInteger(prNumber)) {
+                throw new Error('Unable to resolve PR number for docs-only SlangPy status.');
+              }
+
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              sha = pr.head.sha;
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: 'success',
+              context: 'SlangPy Tests',
+              description: 'Skipped for docs-only change.',
+              target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
             });


### PR DESCRIPTION
## Motivation

Docs-only Slang PRs intentionally skip the expensive downstream SlangPy dispatch, but branch protection still requires the external `SlangPy Tests` commit status. PR #12882 hit the bad shape concretely: its docs-only head commit `43ad075b2` had to be manually unblocked by posting `SlangPy Tests: success` with `Skipped for docs-only change.`

The canary PR #12938 showed the same failure mode. The docs-only filter skipped the `trigger-slangpy-tests` job, and the raw commit statuses only included `license/cla`, leaving the required `SlangPy Tests` context missing forever.

## Proposed solution

Keep the docs-only filter as the source of truth, but make the skip path post the required terminal commit status itself. When `filter.outputs.should-run == 'false'`, a dedicated workflow job posts `SlangPy Tests` as `success` on the PR head SHA with the same skip description used for the manual unblock.

This preserves the existing non-docs dispatch path: source-changing PRs still get the pending status and downstream `shader-slang/slangpy` repository dispatch exactly as before.

## Change summary

- `.github/workflows/ci-slangpy-trigger-test.yml`: add `mark-slangpy-tests-skipped`, which posts a successful `SlangPy Tests` status for docs-only PRs and links it to the Slang-side workflow run.
- `.github/workflows/ci-slangpy-trigger-test.yml`: group existing `$GITHUB_OUTPUT` writes so `actionlint`/ShellCheck passes on the workflow after the change.

## Concepts and vocabulary

- `SlangPy Tests`: an external commit status required by Slang branch protection.
- Docs-only filter: the shared path classifier used to skip build/test/dispatch work when a PR only changes documentation-like files.
- Slang-side trigger run: the `ci-slangpy-trigger-test.yml` workflow run in `shader-slang/slang`, which either dispatches SlangPy or records that dispatch was intentionally skipped.

## Process report

For source-changing PRs, `ci-slangpy-trigger-test.yml` already computes the PR metadata, posts `SlangPy Tests` as pending, and sends a `repository_dispatch` event to `shader-slang/slangpy`. The downstream SlangPy workflow then owns replacing that pending status with the final result.

Docs-only PRs take a different route. The `filter` job checks changed files through `.github/actions/docs-only-filter`; when it emits `should-run=false`, the `trigger-slangpy-tests` job is skipped before the pending status step runs. That input shape is intentional and valid: docs-only PRs should not consume SlangPy runner time. The broken part was that no remaining job owned the required external status context.

The new `mark-slangpy-tests-skipped` job handles exactly that valid skip shape. On normal `pull_request_target` events it uses `context.payload.pull_request.head.sha`, which is the same PR head commit branch protection checks. For manual `workflow_dispatch`, where the event payload has no pull request object, it resolves the requested PR through `pulls.get` and posts the status to `pr.head.sha`. The job posts `context: SlangPy Tests`, `state: success`, and `description: Skipped for docs-only change.`, matching the manual unblock for PR #12882.

The target URL points to the Slang-side workflow run because that run is now the place where the skip decision and status publication are recorded. The existing SlangPy workflow URL remains unchanged for real dispatches, so reviewers still land on downstream logs when SlangPy actually runs.

The `$GITHUB_OUTPUT` edits are mechanical lint cleanup. `actionlint` invokes ShellCheck for embedded workflow shell and flagged the repeated redirects in the existing PR metadata steps. Grouping those writes keeps the same values and makes the edited workflow pass validation.

Validation:

- `actionlint .github/workflows/ci-slangpy-trigger-test.yml`
- `git diff --check HEAD~1 HEAD`
