### PR TITLE
ci: fix nightly Sascha test by looking up the build artifact by name

### DIFF
--- a/.github/workflows/nightly-slang-sascha-test.yml
+++ b/.github/workflows/nightly-slang-sascha-test.yml
@@ -40,6 +40,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           ARTIFACT_NAME="slang-build-windows-x86_64-cl-release"
+          CANDIDATE_LIMIT=5
           STALE_AFTER_DAYS=3
 
           # Look the artifact up by name instead of walking `gh run list`.
@@ -61,17 +62,80 @@ jobs:
           # master or the merge queue, which is the trust boundary the previous
           # `--event merge_group` query had implicitly.
           echo "Looking for the newest unexpired '$ARTIFACT_NAME' built from master..."
-          CANDIDATES=$(gh api \
-            "repos/${{ github.repository }}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100" \
-            --jq '[.artifacts[]
-                   | select(.expired == false)
-                   | select(.workflow_run.head_repository_id
-                            == .workflow_run.repository_id)
-                   | select(.workflow_run.head_branch == "master"
-                            or (.workflow_run.head_branch
-                                | startswith("gh-readonly-queue/master/")))]
-                  | sort_by(.created_at) | reverse | .[0:5][]
-                  | "\(.workflow_run.id)\t\(.created_at)\t\(.workflow_run.head_sha)"')
+          CANDIDATES=""
+          CANDIDATE_COUNT=0
+          PAGE=1
+
+          # The repository artifact endpoint cannot filter by branch. Walk its
+          # newest-first pages until we have enough usable candidates or reach
+          # expired artifacts; filtering only the first page can hide a still-
+          # retained master build behind a busy day's worth of PR artifacts.
+          while [ "$CANDIDATE_COUNT" -lt "$CANDIDATE_LIMIT" ]; do
+            ARTIFACT_PAGE=$(gh api \
+              "repos/${{ github.repository }}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100&page=${PAGE}")
+            PAGE_COUNT=$(jq '.artifacts | length' <<< "$ARTIFACT_PAGE")
+            if [ "$PAGE_COUNT" -eq 0 ]; then
+              break
+            fi
+
+            PAGE_CANDIDATES=$(jq -r \
+              '[.artifacts[]
+                | select(.expired == false)
+                | select(.workflow_run.head_repository_id
+                         == .workflow_run.repository_id)
+                | select(.workflow_run.head_branch == "master"
+                         or (.workflow_run.head_branch
+                             | startswith("gh-readonly-queue/master/")))]
+               | sort_by(.created_at) | reverse | .[]
+               | "\(.workflow_run.id)\t\(.created_at)\t\(.workflow_run.head_sha)\t\(.workflow_run.head_branch)"' \
+              <<< "$ARTIFACT_PAGE")
+
+            while IFS=$'\t' read -r RUN_ID CREATED COMMIT HEAD_BRANCH; do
+              if [ -z "$RUN_ID" ]; then
+                continue
+              fi
+
+              # A merge-queue build uploads its artifact before the rest of CI
+              # finishes. Accept it only if the overall merge_group run passed;
+              # otherwise we could test code that was rejected and never reached
+              # master. A direct master artifact is already built from master and
+              # remains useful even if an unrelated job in its workflow failed.
+              if [ "$HEAD_BRANCH" != "master" ]; then
+                if ! RUN_STATE=$(gh api \
+                  "repos/${{ github.repository }}/actions/runs/${RUN_ID}" \
+                  --jq '[.event, .status, .conclusion] | @tsv'); then
+                  echo "  Could not verify merge-queue run $RUN_ID, skipping it."
+                  continue
+                fi
+                IFS=$'\t' read -r RUN_EVENT RUN_STATUS RUN_CONCLUSION <<< "$RUN_STATE"
+                if [ "$RUN_EVENT" != "merge_group" ] || \
+                   [ "$RUN_STATUS" != "completed" ] || \
+                   [ "$RUN_CONCLUSION" != "success" ]; then
+                  echo "  Skipping merge-queue run $RUN_ID ($RUN_STATUS/$RUN_CONCLUSION)."
+                  continue
+                fi
+              fi
+
+              CANDIDATES+="${RUN_ID}"$'\t'"${CREATED}"$'\t'"${COMMIT}"$'\n'
+              CANDIDATE_COUNT=$((CANDIDATE_COUNT + 1))
+              if [ "$CANDIDATE_COUNT" -ge "$CANDIDATE_LIMIT" ]; then
+                break
+              fi
+            done <<< "$PAGE_CANDIDATES"
+
+            # Artifacts with this name all use the repository's five-day
+            # retention. Since the endpoint is newest-first, once a page reaches
+            # an expired artifact, later pages cannot contain a usable candidate.
+            if jq -e 'any(.artifacts[]; .expired == true)' \
+                >/dev/null <<< "$ARTIFACT_PAGE"; then
+              break
+            fi
+            PAGE=$((PAGE + 1))
+          done
+
+          # Remove the trailing newline so the read loop below does not get an
+          # extra empty record.
+          CANDIDATES=${CANDIDATES%$'\n'}
 
           if [ -z "$CANDIDATES" ]; then
             echo "::error::No unexpired '$ARTIFACT_NAME' artifact built from master."

--- a/.github/workflows/nightly-slang-sascha-test.yml
+++ b/.github/workflows/nightly-slang-sascha-test.yml
@@ -35,49 +35,68 @@ jobs:
         run: |
           Add-Content -Path $env:GITHUB_PATH -Value "C:\\Program Files\\Git\\bin"
 
-      - name: Download Slang build from latest successful merge queue
+      - name: Download latest Slang build for master
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          echo "Finding latest successful merge queue CI run with artifacts..."
           ARTIFACT_NAME="slang-build-windows-x86_64-cl-release"
+          STALE_AFTER_DAYS=3
 
-          # Some CI runs skip builds (e.g. docs-only changes) and have no
-          # artifacts. Search through recent successful runs to find one that
-          # actually produced the artifact we need.
-          RUN_LIST=$(gh run list --repo ${{ github.repository }} \
-            --workflow ci.yml --status success --event merge_group --limit 10 \
-            --json databaseId,headSha,createdAt)
+          # Look the artifact up by name instead of walking `gh run list`.
+          # The run-list endpoint filtered by status+event has twice returned a
+          # stale page: the nightlies on 2026-09-06 and 2026-09-08 were both
+          # handed the same ten 11-day-old runs whose artifacts had long since
+          # expired, even though a usable build from two days earlier was
+          # sitting right there. Querying artifacts by name avoids that index,
+          # and it widens the pool from ci.yml merge-queue runs alone to every
+          # master build -- including sccache-populate, which rebuilds master
+          # every 30 minutes.
+          echo "Looking for the newest unexpired '$ARTIFACT_NAME' built from master..."
+          CANDIDATES=$(gh api \
+            "repos/${{ github.repository }}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100" \
+            --jq '[.artifacts[]
+                   | select(.expired == false)
+                   | select(.workflow_run.head_branch == "master"
+                            or (.workflow_run.head_branch
+                                | startswith("gh-readonly-queue/master/")))]
+                  | sort_by(.created_at) | reverse | .[0:5][]
+                  | "\(.workflow_run.id)\t\(.created_at)\t\(.workflow_run.head_sha)"')
 
+          if [ -z "$CANDIDATES" ]; then
+            echo "::error::No unexpired '$ARTIFACT_NAME' artifact built from master."
+            echo "Artifacts are retained for 5 days, so this means master has not"
+            echo "produced a Windows release build in that window."
+            exit 1
+          fi
+
+          # More than one candidate only to ride out a transient download
+          # failure; the first entry is the one we actually want.
           FOUND=false
-          COUNT=$(echo "$RUN_LIST" | jq length)
-          for i in $(seq 0 $((COUNT - 1))); do
-            RUN_ID=$(echo "$RUN_LIST" | jq -r ".[$i].databaseId")
-            COMMIT=$(echo "$RUN_LIST" | jq -r ".[$i].headSha")
-            CREATED=$(echo "$RUN_LIST" | jq -r ".[$i].createdAt")
-
-            echo "Trying CI run $RUN_ID (commit: ${COMMIT:0:12}, created: $CREATED)..."
-            ERR_FILE=$(mktemp)
+          while IFS=$'\t' read -r RUN_ID CREATED COMMIT; do
+            echo "Trying run $RUN_ID (commit: ${COMMIT:0:12}, created: $CREATED)..."
+            rm -rf slang-build
             if gh run download "$RUN_ID" --repo ${{ github.repository }} \
-                --name "$ARTIFACT_NAME" --dir slang-build/ 2>"$ERR_FILE"; then
-              echo "Downloaded artifact from CI run $RUN_ID"
-              rm -f "$ERR_FILE"
+                --name "$ARTIFACT_NAME" --dir slang-build/; then
+              echo "Downloaded '$ARTIFACT_NAME' from run $RUN_ID"
+              SELECTED_CREATED="$CREATED"
               FOUND=true
               break
-            elif grep -qi "artifact" "$ERR_FILE"; then
-              echo "  No artifact '$ARTIFACT_NAME' in this run, trying next..."
-              rm -f "$ERR_FILE"
-            else
-              echo "  Artifact download failed for run $RUN_ID:"
-              cat "$ERR_FILE"
-              rm -f "$ERR_FILE"
-              exit 1
             fi
-          done
+            echo "  Download failed, trying the next candidate..."
+          done <<< "$CANDIDATES"
 
           if [ "$FOUND" != "true" ]; then
-            echo "No successful CI run with artifact '$ARTIFACT_NAME' found in last 10 runs"
+            echo "::error::Every candidate download of '$ARTIFACT_NAME' failed."
             exit 1
+          fi
+
+          # Testing an old build is better than not testing at all, so this only
+          # warns. It exists so a quiet master shows up as such in the log rather
+          # than masquerading as a run against current sources.
+          AGE_DAYS=$(( ( $(date -u +%s) - $(date -u -d "$SELECTED_CREATED" +%s) ) / 86400 ))
+          echo "Build is ${AGE_DAYS} day(s) old."
+          if [ "$AGE_DAYS" -ge "$STALE_AFTER_DAYS" ]; then
+            echo "::warning::Testing a ${AGE_DAYS}-day-old master build from $SELECTED_CREATED."
           fi
 
           slangcPath=$(find slang-build -name "slangc.exe" -type f | head -1)

--- a/.github/workflows/nightly-slang-sascha-test.yml
+++ b/.github/workflows/nightly-slang-sascha-test.yml
@@ -51,11 +51,22 @@ jobs:
           # and it widens the pool from ci.yml merge-queue runs alone to every
           # master build -- including sccache-populate, which rebuilds master
           # every 30 minutes.
+          #
+          # The head-repository check is what keeps that widening safe. A fork's
+          # default branch is also called master, and `pull_request` CI uploads
+          # its build into this repository's artifact store, so a branch-name
+          # match alone would let a fork PR hand us the slangc.exe we then run
+          # with GH_TOKEN in the environment. Requiring the run's head
+          # repository to be this repository restricts us to code that reached
+          # master or the merge queue, which is the trust boundary the previous
+          # `--event merge_group` query had implicitly.
           echo "Looking for the newest unexpired '$ARTIFACT_NAME' built from master..."
           CANDIDATES=$(gh api \
             "repos/${{ github.repository }}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100" \
             --jq '[.artifacts[]
                    | select(.expired == false)
+                   | select(.workflow_run.head_repository_id
+                            == .workflow_run.repository_id)
                    | select(.workflow_run.head_branch == "master"
                             or (.workflow_run.head_branch
                                 | startswith("gh-readonly-queue/master/")))]


### PR DESCRIPTION
## Motivation

The `Nightly Slang Sascha Test` workflow has been failing intermittently. Two recent examples are
[run 34186359215](https://github.com/shader-slang/slang/actions/runs/34186359215) (2026-09-08) and
[run 34011016534](https://github.com/shader-slang/slang/actions/runs/34011016534) (2026-09-06). In
both, the `Download Slang build from latest successful merge queue` step failed and the shader
compile never ran.

The step used this run-list query:

```bash
RUN_LIST=$(gh run list --repo ${{ github.repository }} \
  --workflow ci.yml --status success --event merge_group --limit 10 \
  --json databaseId,headSha,createdAt)
```

On both failing days it returned the same stale set of ten runs from 2026-08-26 through
2026-08-28. Their five-day artifacts had expired, so every download failed. A usable
`slang-build-windows-x86_64-cl-release` artifact from 2026-09-04 was present at the time. The
2026-09-07 nightly, using the same script and runner image, received that run first and succeeded.

The stale result was not a normal page boundary: the returned IDs were at positions 52-64 of the
correct ordering and skipped entries inside that range. Repeating the query later returned the
correct head, which points to a transiently inconsistent filtered workflow-run index rather than
an absence of builds.

## Proposed solution

Ask the artifact endpoint the question the step actually needs answered:

```bash
gh api "repos/$REPO/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100&page=${PAGE}"
```

The endpoint reports expiration directly and avoids the run-list index that produced stale
results. Because it cannot filter by branch, the selector walks newest-first pages until it finds
five usable candidates or reaches the expired portion of the five-day retention window. This is
important in this repository: a busy day can put more than 100 PR artifacts ahead of a retained
master artifact.

The artifact is also produced by `sccache-populate.yml`, which rebuilds master every 30 minutes.
The selector therefore accepts repository-owned runs whose head is either `master` or
`gh-readonly-queue/master/*`, rather than limiting the supply to `ci.yml` merge-queue runs.

Widening the pool requires explicit provenance checks. A fork's default branch can also be named
`master`, and `pull_request` CI uploads fork builds into this repository's artifact store. The
nightly later executes the selected `slangc.exe` while `GH_TOKEN` is set, so branch name alone is
not a sufficient trust boundary. Requiring
`workflow_run.head_repository_id == workflow_run.repository_id` restricts candidates to this
repository.

Merge-queue heads need one additional check. Their build job uploads the artifact before the rest
of the workflow finishes, so artifact existence proves only that the compiler built. The selector
looks up each merge-queue run and accepts it only when the event is `merge_group`, the run is
completed, and its conclusion is `success`. This prevents the nightly from testing a provisional
merge result that failed CI and never reached master. Direct `master` artifacts do not need this
extra gate because their source commit has already reached master.

The step distinguishes two operational conditions:

- If no usable artifact exists inside the retention window, it fails with a specific error.
- If the selected build is at least three days old, it warns but continues. Testing an older
  retained master build is more useful than skipping the shader test, while the warning makes a
  quiet master visible in the log.

## Change summary

| File | Change |
|---|---|
| `.github/workflows/nightly-slang-sascha-test.yml` | Replace the `gh run list` walk with a paginated, by-name artifact query. Restrict results to repository-owned `master` or merge-queue runs, require successful completion for merge-queue candidates, retain five candidates for download fallback, and report empty or stale retention windows clearly. Rename the step to `Download latest Slang build for master` because it is no longer merge-queue-specific. |

No other workflow uses this lookup pattern.

## Concepts and vocabulary

- **Artifact retention** - `slang-build-*` artifacts expire five days after upload. The artifact
  record remains visible with `expired: true`, but it can no longer be downloaded.
- **Merge-queue head** - a `merge_group` run uses a branch such as
  `gh-readonly-queue/master/pr-<n>-<sha>`, not plain `master`.
- **`head_repository_id` vs. `repository_id`** - for a fork PR, the head repository is the fork
  while the run belongs to `shader-slang/slang`. Comparing these fields establishes artifact
  provenance independently of contributor-controlled branch names.
- **`sccache-populate.yml`** - a scheduled workflow that rebuilds master's HEAD every 30 minutes
  and uploads the same Windows release artifact.

## Process report

**Why the query changed instead of increasing the retry count.** Raising `--limit 10` would still
depend on the index that returned an internally inconsistent result, and it would keep inferring
artifact availability from run metadata plus failed downloads. Querying artifacts by name makes
the artifact record the source of truth.

**Why pagination belongs in the selector.** The endpoint applies `per_page` before the local `jq`
branch and provenance filters. The repository currently has more than 12,000 records with this
artifact name, and live pages can cover less than a day of CI activity. Filtering only page one can
therefore return no master candidate even though an unexpired one exists on a later page. The
selector processes pages in API order, filters each page, and stops after five usable candidates.
It also stops once it encounters expired artifacts because this artifact has one producer and the
repository's five-day retention applies uniformly; older pages cannot then contain a downloadable
candidate.

**Why run conclusion is checked for merge-queue artifacts but not direct master artifacts.** An
artifact from plain `master` contains code that is already on the branch the nightly is meant to
test. A merge-queue head is provisional: `ci-slang-build.yml` can upload its artifact before a
different job fails, after which that merge group is rejected. For that shape, build success is not
equivalent to admission to master. Looking up the run's event, status, and conclusion preserves the
old successful-`merge_group` invariant at the point where the candidate is selected.

**Why the head-repository check belongs in the selector.** A fork-owned artifact is a valid API
record but not a valid executable input for this trusted nightly. Provenance exists on the run
record, not in the downloaded binary, so the candidate must be rejected before download rather
than inspected after execution has become possible.

**Why the candidate loop remains.** The first candidate is the desired build. Keeping up to five
allows a transient download failure to fall back without failing the nightly. The step removes any
partial extraction before each attempt so one candidate cannot contaminate the next.

**Why staleness warns instead of failing.** A hard freshness threshold would turn long weekends or
quiet periods into false failures even when a retained master compiler is available. The warning
preserves the diagnostic signal without suppressing the actual shader test.

## Test Plan

The selector was exercised against the live `shader-slang/slang` API:

- With production page size, it selected five current, repository-owned candidates.
- With a page size of ten to force pagination, it crossed multiple pages and still selected five
  valid candidates in newest-first order.
- Known merge-group run `33799424731` reports `merge_group/completed/failure` and is rejected by the
  new run-state gate.
- The by-name query identifies the retained 2026-09-04 master build that was available during both
  reported nightly failures.
- The fork filter yields no fork-owned survivors; synthetic fork-owned `master` and spoofed
  `gh-readonly-queue/master/*` records are rejected.
- The empty-result and three-day staleness branches were exercised independently.
- The workflow parses as YAML. The extracted Bash block passes `bash -n` and ShellCheck, and the
  file passes `prettier --check` and `git diff --check`.

A real Windows end-to-end dispatch is not available from the fork branch because
`workflow_dispatch` only fires for branches in `shader-slang/slang`; the first full run will be a
manual dispatch on `master` or the nightly after merge.
