### PR TITLE
Add experimental functional aggregate operations

### DIFF
--- a/source/standard-modules/CMakeLists.txt
+++ b/source/standard-modules/CMakeLists.txt
@@ -50,3 +50,6 @@ add_subdirectory(experimental)
 
 # Build the experimental numeric interface modules.
 add_subdirectory(numerics)
+
+# Build the experimental functional module.
+add_subdirectory(functional)

--- a/source/standard-modules/README.md
+++ b/source/standard-modules/README.md
@@ -39,10 +39,13 @@ source/standard-modules/
 ├── experimental/                           # Experimental module subdirectory
 │   ├── CMakeLists.txt                      # Experimental module build logic
 │   └── workgraph.slang                     # Workgraph module entry point
-└── numerics/                               # Experimental numeric interface modules
-    ├── CMakeLists.txt                      # Numeric module build logic
-    ├── numerics.slang                      # `slang.numerics` entry point
-    └── differentiable.slang                # Differentiable annex entry point
+├── numerics/                               # Experimental numeric interface modules
+│   ├── CMakeLists.txt                      # Numeric module build logic
+│   ├── numerics.slang                      # `slang.numerics` entry point
+│   └── differentiable.slang                # Differentiable annex entry point
+└── functional/                             # Experimental higher-order operations
+    ├── CMakeLists.txt                      # Functional module build logic
+    └── functional.slang                    # `slang.functional` entry point
 ```
 
 ## Files Involved
@@ -59,6 +62,7 @@ source/standard-modules/
 - `source/standard-modules/neural/CMakeLists.txt` - Neural module specific build logic
 - `source/standard-modules/experimental/CMakeLists.txt` - Experimental module specific build logic
 - `source/standard-modules/numerics/CMakeLists.txt` - Experimental numeric module build logic
+- `source/standard-modules/functional/CMakeLists.txt` - Experimental functional module build logic
 - `source/slang/CMakeLists.txt` - Uses the standard module config header internally for the slang library
 
 ### C++ Code
@@ -100,6 +104,7 @@ For example, `import slang.neural;` resolves to `slang/neural.slang-module`, and
 `import experimental.workgraph;` resolves to `experimental/workgraph.slang-module`.
 The experimental numeric imports resolve to `slang/numerics.slang-module` and
 `slang/numerics/differentiable.slang-module`.
+The experimental functional import resolves to `slang/functional.slang-module`.
 
 This ensures that both the C++ runtime search logic and the CMake build logic use exactly the same
 path configuration, while keeping the implementation details internal to the slang library.

--- a/source/standard-modules/functional/CMakeLists.txt
+++ b/source/standard-modules/functional/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Build the experimental functional module and place it in the standard-module tree.
+
+set(functional_standard_module_root
+    "${slang_BINARY_DIR}/$<CONFIG>/${slang_library_dir}/${SLANG_STANDARD_MODULE_DIR_NAME}"
+)
+set(functional_output_dir "${functional_standard_module_root}/slang")
+set(functional_module_file "${functional_output_dir}/functional.slang-module")
+
+if(SLANG_GENERATORS_PATH)
+    if(CMAKE_HOST_WIN32)
+        set(CMAKE_HOST_EXECUTABLE_SUFFIX ".exe")
+    else()
+        set(CMAKE_HOST_EXECUTABLE_SUFFIX "")
+    endif()
+    set(SLANG_COMPILER
+        "${SLANG_GENERATORS_PATH}/slang-bootstrap${CMAKE_HOST_EXECUTABLE_SUFFIX}"
+    )
+    set(SLANG_COMPILER_DEPENDENCY)
+else()
+    set(SLANG_COMPILER slang-bootstrap)
+    set(SLANG_COMPILER_DEPENDENCY slang-bootstrap)
+endif()
+
+set(SLANG_COMPILER_CORE_MODULE_ARGS
+    -load-core-module
+    ${core_module_archive_without_timestamp}
+)
+set(SLANG_COMPILER_EXTRA_DEPS generate_core_module)
+
+add_custom_command(
+    OUTPUT ${functional_module_file}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${functional_output_dir}
+    COMMAND
+        ${SLANG_COMPILER} ${SLANG_COMPILER_CORE_MODULE_ARGS}
+        -experimental-feature ${CMAKE_CURRENT_SOURCE_DIR}/functional.slang -o
+        ${functional_module_file}
+    DEPENDS
+        functional.slang
+        ${SLANG_COMPILER_DEPENDENCY}
+        ${SLANG_COMPILER_EXTRA_DEPS}
+    VERBATIM
+)
+
+add_custom_target(slang-functional-module ALL DEPENDS ${functional_module_file})
+set_target_properties(slang-functional-module PROPERTIES FOLDER generated)
+
+install(
+    FILES ${functional_module_file}
+    DESTINATION ${SLANG_STANDARD_MODULE_INSTALL_DIR}/slang
+)

--- a/source/standard-modules/functional/functional.slang
+++ b/source/standard-modules/functional/functional.slang
@@ -1,0 +1,154 @@
+/**
+Experimental higher-order operations for finite builtin aggregate types.
+
+@remarks Importers must enable experimental features. The API is intentionally outside `core` so
+its names and signatures can evolve while practical experience is gathered.
+*/
+[ExperimentalModule]
+module functional;
+
+/// Adds higher-order element operations to fixed-size arrays.
+public extension<T, let N : int> Array<T, N>
+{
+    /// Applies `function` to every element and returns the results in an array of the same length.
+    [ForceInline]
+    public Array<U, N> map<U, F : IFunc<U, T>>(F function)
+    {
+        static_assert(N != int.maxValue, "map requires an array with a statically known length");
+        Array<U, N> result;
+        for (int index = 0; index < N; ++index)
+            result[index] = function(this[index]);
+        return result;
+    }
+
+    /// Applies `function` to every element and returns the results in an array of the same length.
+    [ForceInline]
+    public Array<U, N> map<U>(functype(T) -> U function)
+    {
+        static_assert(N != int.maxValue, "map requires an array with a statically known length");
+        Array<U, N> result;
+        for (int index = 0; index < N; ++index)
+            result[index] = function(this[index]);
+        return result;
+    }
+
+    /// Generates an array by evaluating `elementAt` once for every element index.
+    [ForceInline]
+    public static This generate<F : IFunc<T, int>>(F elementAt)
+    {
+        static_assert(
+            N != int.maxValue,
+            "generate requires an array with a statically known length");
+        This result;
+        for (int index = 0; index < N; ++index)
+            result[index] = elementAt(index);
+        return result;
+    }
+
+    /// Initializes an array by evaluating `elementAt` once for every element index.
+    [ForceInline]
+    public __init<F : IFunc<T, int>>(F elementAt)
+    {
+        this = This.generate(elementAt);
+    }
+}
+
+/// Adds higher-order element operations to builtin vectors.
+public extension<T, let N : int> vector<T, N>
+{
+    /// Applies `function` to every element and returns the results in a vector of the same length.
+    [ForceInline]
+    public vector<U, N> map<U, F : IFunc<U, T>>(F function)
+    {
+        vector<U, N> result;
+        [ForceUnroll]
+        for (int index = 0; index < N; ++index)
+            result[index] = function(this[index]);
+        return result;
+    }
+
+    /// Applies `function` to every element and returns the results in a vector of the same length.
+    [ForceInline]
+    public vector<U, N> map<U>(functype(T) -> U function)
+    {
+        vector<U, N> result;
+        [ForceUnroll]
+        for (int index = 0; index < N; ++index)
+            result[index] = function(this[index]);
+        return result;
+    }
+
+    /// Generates a vector by evaluating `elementAt` once for every element index.
+    [ForceInline]
+    public static This generate<F : IFunc<T, int>>(F elementAt)
+    {
+        This result;
+        [ForceUnroll]
+        for (int index = 0; index < N; ++index)
+            result[index] = elementAt(index);
+        return result;
+    }
+
+    /// Initializes a vector by evaluating `elementAt` once for every element index.
+    [ForceInline]
+    public __init<F : IFunc<T, int>>(F elementAt)
+    {
+        this = This.generate(elementAt);
+    }
+}
+
+/// Adds higher-order element operations to builtin matrices.
+public extension<T, let R : int, let C : int, let L : int> matrix<T, R, C, L>
+{
+    /// Applies `function` to every element and preserves the matrix dimensions and layout.
+    [ForceInline]
+    public matrix<U, R, C, L> map<U, F : IFunc<U, T>>(F function)
+    {
+        matrix<U, R, C, L> result;
+        [ForceUnroll]
+        for (int row = 0; row < R; ++row)
+        {
+            [ForceUnroll]
+            for (int column = 0; column < C; ++column)
+                result[row][column] = function(this[row][column]);
+        }
+        return result;
+    }
+
+    /// Applies `function` to every element and preserves the matrix dimensions and layout.
+    [ForceInline]
+    public matrix<U, R, C, L> map<U>(functype(T) -> U function)
+    {
+        matrix<U, R, C, L> result;
+        [ForceUnroll]
+        for (int row = 0; row < R; ++row)
+        {
+            [ForceUnroll]
+            for (int column = 0; column < C; ++column)
+                result[row][column] = function(this[row][column]);
+        }
+        return result;
+    }
+
+    /// Generates a matrix by evaluating `elementAt` once for every row and column index pair.
+    [ForceInline]
+    public static This generate<F : IFunc<T, int, int>>(F elementAt)
+    {
+        This result;
+        [ForceUnroll]
+        for (int row = 0; row < R; ++row)
+        {
+            [ForceUnroll]
+            for (int column = 0; column < C; ++column)
+                result[row][column] = elementAt(row, column);
+        }
+        return result;
+    }
+
+    /// Initializes a matrix by evaluating `elementAt` once for every row and column index pair.
+    [ForceInline]
+    public __init<F : IFunc<T, int, int>>(F elementAt)
+    {
+        this = This.generate(elementAt);
+    }
+}

--- a/tests/functional/codegen.slang
+++ b/tests/functional/codegen.slang
@@ -1,0 +1,40 @@
+// Verify that functional operations specialize their callable values before target emission.
+
+//TEST:SIMPLE: -target hlsl -entry computeMain -stage compute -experimental-feature -validate-ir -o functional.hlsl
+//TEST:SIMPLE: -target spirv-asm -entry computeMain -stage compute -experimental-feature -validate-ir -o functional.spv-asm
+//TEST:SIMPLE: -target glsl -entry computeMain -stage compute -experimental-feature -validate-ir -o functional.glsl
+//TEST:SIMPLE: -target wgsl -entry computeMain -stage compute -experimental-feature -validate-ir -o functional.wgsl
+//TEST:SIMPLE: -target metal -entry computeMain -stage compute -experimental-feature -validate-ir -o functional.metal
+//TEST:SIMPLE: -target cpp -entry computeMain -stage compute -experimental-feature -validate-ir -o functional.cpp
+//TEST:SIMPLE: -target cuda -entry computeMain -stage compute -experimental-feature -validate-ir -o functional.cuda.cpp
+
+import slang.functional;
+
+RWStructuredBuffer<int4> outputBuffer;
+
+int quantize(float value)
+{
+    return int(value * 2.0);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    int baseValue = 1;
+    Array<int, 4> arrayValue = Array<int, 4>((int index) => baseValue + index);
+    let mappedArray = arrayValue.map((int value) => value + baseValue);
+
+    float4 vectorValue = float4((int index) => float(index) + 0.5);
+    let mappedVector = vectorValue.map(quantize);
+
+    matrix<int, 2, 2> matrixValue =
+        matrix<int, 2, 2>((int row, int column) => row * 2 + column);
+    let mappedMatrix = matrixValue.map((int value) => value + baseValue);
+
+    outputBuffer[0] = int4(
+        mappedArray[0] + mappedMatrix[0][0],
+        mappedArray[1] + mappedMatrix[0][1],
+        mappedVector[2] + mappedMatrix[1][0],
+        mappedVector[3] + mappedMatrix[1][1]);
+}

--- a/tests/functional/experimental-feature-required.slang
+++ b/tests/functional/experimental-feature-required.slang
@@ -1,0 +1,6 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK):
+
+import slang.functional;
+/*CHECK:
+       ^^^^^ 'slang/functional' is an experimental module, need to enable '-experimental-feature' to load this module
+*/

--- a/tests/functional/import-required.slang
+++ b/tests/functional/import-required.slang
@@ -1,0 +1,7 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK, non-exhaustive):
+
+int4 apply(int4 value)
+{
+    return value.map((int element) => element + 1);
+//CHECK:         ^^^ 'map' is not a member of 'vector<int,4>'.
+}

--- a/tests/functional/numerics-interoperability.slang
+++ b/tests/functional/numerics-interoperability.slang
@@ -1,0 +1,24 @@
+// Verify that the extensions from slang.functional and slang.numerics coexist in either import
+// order.
+
+//TEST:SIMPLE: -target hlsl -entry computeMain -stage compute -experimental-feature -DFUNCTIONAL_FIRST -o functional-first.hlsl
+//TEST:SIMPLE: -target hlsl -entry computeMain -stage compute -experimental-feature -o numerics-first.hlsl
+
+#ifdef FUNCTIONAL_FIRST
+import slang.functional;
+import slang.numerics;
+#else
+import slang.numerics;
+import slang.functional;
+#endif
+
+RWStructuredBuffer<float4> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    float3 generated = float3((int index) => float(index + 1));
+    float3 mapped = generated.map((float value) => value + 1.0);
+    outputBuffer[0] = float4(sin(mapped), 1.0);
+}

--- a/tests/functional/runtime-values.slang
+++ b/tests/functional/runtime-values.slang
@@ -1,0 +1,83 @@
+// Verify generation and mapping for arrays, vectors, and matrices with function values and
+// capturing lambdas.
+
+//TEST(compute):COMPARE_COMPUTE(filecheck-buffer=CHECK):-cpu -output-using-type -Xslang -experimental-feature
+
+// CHECK: type: int32_t
+// CHECK-NEXT: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 1
+// CHECK-NEXT: 1
+
+//TEST_INPUT:ubuffer(data=[0 0 0 0 0 0 0 0 0 0 0 0], stride=4):out,name=outputBuffer
+
+import slang.functional;
+
+RWStructuredBuffer<int> outputBuffer;
+
+float addHalf(int value)
+{
+    return float(value) + 0.5;
+}
+
+int quantize(float value)
+{
+    return int(value * 2.0);
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    int arrayBase = 2;
+    Array<int, 4> generatedArray = Array<int, 4>((int index) => arrayBase + index);
+    Array<int, 4> factoryArray = Array<int, 4>.generate((int index) => index * index);
+    let functionMappedArray = generatedArray.map(addHalf);
+    int arrayOffset = 10;
+    let closureMappedArray =
+        generatedArray.map((int value) => float(value + arrayOffset) + 0.25);
+
+    outputBuffer[0] = int(generatedArray[0] == 2 && generatedArray[3] == 5);
+    outputBuffer[1] = int(factoryArray[1] == 1 && factoryArray[3] == 9);
+    outputBuffer[2] = int(functionMappedArray[0] == 2.5 && functionMappedArray[3] == 5.5);
+    outputBuffer[3] = int(closureMappedArray[0] == 12.25 && closureMappedArray[3] == 15.25);
+
+    float4 generatedVector = float4((int index) => float(index) + 0.5);
+    int4 factoryVector = int4.generate((int index) => index * 3);
+    let functionMappedVector = generatedVector.map(quantize);
+    float vectorScale = 2.0;
+    let closureMappedVector = generatedVector.map((float value) => value * vectorScale);
+
+    outputBuffer[4] = int(generatedVector.x == 0.5 && generatedVector.w == 3.5);
+    outputBuffer[5] = int(factoryVector.x == 0 && factoryVector.w == 9);
+    outputBuffer[6] = int(functionMappedVector.x == 1 && functionMappedVector.w == 7);
+    outputBuffer[7] = int(closureMappedVector.x == 1.0 && closureMappedVector.w == 7.0);
+
+    int matrixBase = 20;
+    matrix<int, 2, 3, kRowMajorMatrixLayout> generatedMatrix =
+        matrix<int, 2, 3, kRowMajorMatrixLayout>(
+            (int row, int column) => matrixBase + row * 10 + column);
+    matrix<int, 2, 3, kRowMajorMatrixLayout> factoryMatrix =
+        matrix<int, 2, 3, kRowMajorMatrixLayout>.generate(
+            (int row, int column) => row * 10 + column);
+    matrix<float, 2, 3, kRowMajorMatrixLayout> functionMappedMatrix =
+        generatedMatrix.map(addHalf);
+    int matrixOffset = 5;
+    matrix<float, 2, 3, kRowMajorMatrixLayout> closureMappedMatrix =
+        generatedMatrix.map((int value) => float(value + matrixOffset) + 0.25);
+
+    outputBuffer[8] = int(generatedMatrix[0][0] == 20 && generatedMatrix[1][2] == 32);
+    outputBuffer[9] = int(factoryMatrix[0][0] == 0 && factoryMatrix[1][2] == 12);
+    outputBuffer[10] =
+        int(functionMappedMatrix[0][0] == 20.5 && functionMappedMatrix[1][2] == 32.5);
+    outputBuffer[11] =
+        int(closureMappedMatrix[0][0] == 25.25 && closureMappedMatrix[1][2] == 37.25);
+}

--- a/tests/functional/unsized-array.slang
+++ b/tests/functional/unsized-array.slang
@@ -1,0 +1,48 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK, non-exhaustive): -target hlsl -entry computeMain -stage compute -experimental-feature
+
+import slang.functional;
+
+int increment(int value)
+{
+    return value + 1;
+}
+
+void mapUnsizedArrayWithLambda(int values[])
+{
+    let result = values.map((int value) => value + 1);
+    /*CHECK:
+                           ^ static assertion failed, map requires an array with a statically known length
+    */
+}
+
+void mapUnsizedArrayWithFunction(int values[])
+{
+    let result = values.map(increment);
+//CHECK: static assertion failed, map requires an array with a statically known length
+}
+
+int generateForArray<T, let N : int>(Array<T, N> values)
+{
+    let result = Array<int, N>.generate((int index) => index);
+    /*CHECK:
+                                       ^ static assertion failed, generate requires an array with a statically known length
+    */
+    return result[0];
+}
+
+int generateForUnsizedArray(int values[])
+{
+    return generateForArray(values);
+}
+
+RWStructuredBuffer<int> outputBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void computeMain()
+{
+    int values[1] = {0};
+    mapUnsizedArrayWithLambda(values);
+    mapUnsizedArrayWithFunction(values);
+    outputBuffer[0] = generateForUnsizedArray(values);
+}


### PR DESCRIPTION
## Motivation

Slang's main fixed-size aggregate types do not currently share an idiomatic API for either mapping their elements or generating a value from its conceptual index space.
That makes code such as the following unavailable today:

```slang
import slang.functional;

float4 values = float4((int index) => float(index) + 0.5);
int4 mapped = values.map((float value) => int(value * 2.0));

matrix<float, 2, 3> table = matrix<float, 2, 3>(
    (int row, int column) => a[row] + b[column] + 2.0);
```

Arrays, vectors, and matrices already have similar finite index spaces, but their APIs do not make that relationship visible.
Putting an initial API in an opt-in experimental module lets us gather experience with its naming, callable constraints, and overload behavior before considering a stable or core-module surface.

## Proposed solution

Add an experimental compiled standard module named `slang.functional`.
The module contributes public extensions on `Array<T, N>`, `vector<T, N>`, and `matrix<T, R, C, L>` with a consistent set of operations:

- `map<U, F : IFunc<U, T>>(F)` for lambdas and other interface-conforming callable values;
- `map<U>(functype(T) -> U)` for ordinary function values, which do not currently conform to `IFunc`;
- a static `generate` factory whose callable receives one index for arrays and vectors or a row/column pair for matrices; and
- a constructor with the same `IFunc`-based generation semantics.

`map` preserves the input dimensions and, for matrices, the layout parameter while allowing the element type to change.
The constructors deliberately accept only the `IFunc` form:
this keeps calls such as `float4x4(foo)` from silently treating an unrelated two-integer function as a generating constructor, while explicit lambdas remain concise.

The extensions remain unconstrained over element type for this first experimental version.
Backend-specific element restrictions are therefore diagnosed by the existing operations that eventually consume those types.

## Change summary

- `source/standard-modules/functional/functional.slang` defines the experimental extensions and their public API.
- `source/standard-modules/functional/CMakeLists.txt` compiles and installs `slang/functional.slang-module` using the generated core-module archive.
- `source/standard-modules/CMakeLists.txt` includes the new module in the standard-module build.
- `source/standard-modules/README.md` documents its source and installed import path.
- `tests/functional/` covers runtime values, callable forms, cross-target lowering, visibility, experimental gating, unsized-array diagnostics, matrix layout preservation, and coexistence with `slang.numerics` in both import orders.

## Concepts and vocabulary

- `IFunc<TR, each TP>` is Slang's callable interface, with the result type first and parameter types following it.
  Lambdas and callable structs can satisfy this constraint.
- `functype(T) -> U` is the current explicit type spelling for an ordinary function value.
  It needs a separate `map` overload because function-typed expressions do not yet conform to `IFunc`.
- An unsized array is currently represented as `Array<T, int.maxValue>`.
  That sentinel representation allows the same extension to participate in lookup for both sized and unsized array spellings.
- A compiled standard module is serialized during the Slang build and installed under the path that corresponds to its import name.

## Process report

Consider `float4((int index) => float(index))`.
Importing `slang.functional` loads the serialized module and makes its public vector extension and public constructor visible during member lookup.
The constructor calls `This.generate`, which evaluates the callable once for each index and writes the result directly into the aggregate.
The array and matrix constructors follow the same path, with the matrix generator passing `row` and `column` separately.
Keeping the constructor as a small synonym for `generate` gives both entry points a single semantic implementation.

Now consider `values.map((float value) => int(value))`.
The lambda satisfies the `IFunc<U, T>` overload, and the implementation directly walks the source aggregate and writes a same-shaped result.
It does not route through the generating constructor:
mapping already has the source element in hand, so a direct loop is the simpler representation and avoids turning source indexing into an extra closure.
An ordinary named function instead selects the `functype` overload.
Both paths are force-inlined so their callable representation is specialized before target emission;
the cross-target test also runs IR validation for HLSL, SPIR-V assembly, GLSL, WGSL, Metal, C++, and CUDA.

Vector and matrix bounds are small, statically known language limits, so those loops are explicitly unrolled.
Array loops are not force-unrolled because arrays can be much larger and because the current unsized-array sentinel must be rejected by the API's explicit guard before an unroller sees it.

Consider this example:

```slang
void apply(int values[])
{
    let result = values.map((int value) => value + 1);
}
```

The parameter type reaches the extension in the compiler's canonical current representation as `Array<int, int.maxValue>`.
That shape is intentional input to lookup today, even though using a sentinel for the unknown length is a language-design limitation that should eventually be replaced.
Each array `map` overload therefore asserts that `N != int.maxValue`, and `generate` performs the same check.
This keeps the rejection at the operation boundary and produces a targeted diagnostic instead of letting a nonsensical sentinel-sized loop reach lowering.
The diagnostic test specializes calls through both callable forms and through `generate` to verify those guards.

For matrices, every result type carries `L` through unchanged.
The runtime test uses `kRowMajorMatrixLayout` explicitly while mapping from `int` to `float`, so it would fail to type-check if the implementation silently reverted to the default matrix layout.

The build path is `source/standard-modules/CMakeLists.txt` to `slang-functional-module`, whose custom command invokes `slang-bootstrap` with the generated core-module archive and `-experimental-feature`, writes `slang/functional.slang-module`, and installs that artifact beside the other versioned standard modules.

An isolated RelWithDebInfo build from current `master` completed `slangc`, `slang-test`, `slang-functional-module`, and the interoperability test's `slang-numerics-modules` dependency with zero warnings or errors.
The focused `tests/functional` run from that build passed all 14 generated test cases.
The CPU execution produced twelve successful value checks, and the generated module compiled for all seven target formats listed above.
The local test installation did not include the external FileCheck executable, so the twelve CPU values were also inspected directly in the generated output.

No compiler helper, fallback lookup, alternate AST/IR representation, or target-specific lowering special case is added by this change.
The alternatives intentionally left out are core-module placement, implementing `map` through the generating constructors, a `functype` constructor overload, and `mapRows`;
each can be reconsidered after experience with the experimental surface.
