### PR TITLE
Retry transient CMake options checkouts

### DIFF
--- a/.github/workflows/cmake-options-build-container.yml
+++ b/.github/workflows/cmake-options-build-container.yml
@@ -28,11 +28,28 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Checkout (attempt 1)
+        id: checkout
+        continue-on-error: true
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           sparse-checkout: .github/cmake-options-matrix.json
           sparse-checkout-cone-mode: false
+
+      - name: Wait before retrying checkout
+        if: steps.checkout.outcome == 'failure'
+        shell: bash
+        run: sleep 30
+
+      - name: Checkout (attempt 2)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/cmake-options-matrix.json
+          sparse-checkout-cone-mode: false
+
       - id: set-matrix
         run: |
           {
@@ -63,7 +80,24 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Checkout (attempt 1)
+        id: checkout
+        continue-on-error: true
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          submodules: "recursive"
+          fetch-depth: "250"
+          fetch-tags: true
+
+      - name: Wait before retrying checkout
+        if: steps.checkout.outcome == 'failure'
+        shell: bash
+        run: sleep 30
+
+      - name: Checkout (attempt 2)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           submodules: "recursive"

--- a/.github/workflows/cmake-options-build.yml
+++ b/.github/workflows/cmake-options-build.yml
@@ -50,11 +50,28 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Checkout (attempt 1)
+        id: checkout
+        continue-on-error: true
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           sparse-checkout: .github/cmake-options-matrix.json
           sparse-checkout-cone-mode: false
+
+      - name: Wait before retrying checkout
+        if: steps.checkout.outcome == 'failure'
+        shell: bash
+        run: sleep 30
+
+      - name: Checkout (attempt 2)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/cmake-options-matrix.json
+          sparse-checkout-cone-mode: false
+
       - id: set-matrix
         run: |
           {
@@ -92,7 +109,24 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Checkout (attempt 1)
+        id: checkout
+        continue-on-error: true
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          submodules: "recursive"
+          fetch-depth: "250"
+          fetch-tags: true
+
+      - name: Wait before retrying checkout
+        if: steps.checkout.outcome == 'failure'
+        shell: bash
+        run: sleep 30
+
+      - name: Checkout (attempt 2)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
           submodules: "recursive"


### PR DESCRIPTION
## Motivation

The scheduled CMake Options run on September 5 failed even though none of the CMake option
combinations had a configuration or build error. In the
`windows-aarch64-debug / build (SLANG_ENABLE_EXAMPLES)` job, `actions/checkout` could not connect
to `github.com:443` while fetching the repository and later failed the direct fetch of the pinned
`external/lua` commit for the same reason. The other 419 jobs succeeded, and rerunning the failed
jobs made the workflow pass on attempt 2:
https://github.com/shader-slang/slang/actions/runs/33954097496

Once failure notifications are enabled, this kind of transient checkout outage would produce an
alert that looks like a CMake regression.

## Proposed solution

Give each checkout in the reusable CMake Options workflows one delayed retry. The first attempt
uses `continue-on-error` only so the workflow can inspect its original `outcome`. When that outcome
is `failure`, the job waits 30 seconds and runs the same pinned checkout action with the same inputs
again. The second attempt retains normal failure behavior, so persistent checkout problems still
fail the job and reach the aggregate `check-cmake` gate.

The retry is scoped to checkout. Configure and build steps remain single-attempt operations, so a
real CMake regression is neither retried nor hidden.

## Change summary

- `.github/workflows/cmake-options-build.yml` retries the sparse setup checkout and each native
  build-matrix checkout.
- `.github/workflows/cmake-options-build-container.yml` applies the same behavior to the container
  workflow's setup and build jobs.

## Concepts and vocabulary

- **Setup checkout**: the sparse checkout that reads `.github/cmake-options-matrix.json` before the
  reusable workflow expands its matrix.
- **Build checkout**: the full recursive-submodule checkout performed independently by each matrix
  entry.
- **Step outcome**: the result before `continue-on-error` is applied. It remains `failure` and can
  trigger the retry even though the job is temporarily allowed to continue.

## Process report

Both reusable workflows have two checkout boundaries: `setup` obtains the matrix definition, then
each `build` matrix job obtains the source and recursive submodules. A transient network failure at
either boundary prevents all downstream work for that job, so both boundaries use the same retry
structure rather than protecting only the checkout that happened to fail on September 5.

For each boundary, `Checkout (attempt 1)` records the checkout action's unmodified outcome. A
conditional bash step waits 30 seconds only after a failure, and `Checkout (attempt 2)` repeats the
identical action inputs. If the first checkout succeeds, both conditional steps are skipped. If the
second checkout fails, its default failure behavior stops the job. This preserves the existing
contract of `check-cmake`: it sees a failure only after checkout has failed twice or after a real
configure/build failure.

The failed input shape here is valid and expected: a matrix job starts from an empty hosted runner
and asks GitHub for the repository plus its pinned submodules. The malformed state is external—a
temporary inability to reach GitHub—not something an upstream workflow producer can canonicalize
or repair. Retrying at the checkout boundary is therefore the narrow owner of the recovery. A
workflow-level rerun was rejected because it would repeat unrelated successful matrix work, while
continuing after the final checkout failure was rejected because downstream steps require a
complete source tree.
