### PR TITLE
Let Slang CI cherry-pick a SlangPy PR into SlangPy CI runs

### DIFF
--- a/.github/workflows/ci-slangpy-trigger-test.yml
+++ b/.github/workflows/ci-slangpy-trigger-test.yml
@@ -27,6 +27,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Names a SlangPy PR to merge into SlangPy `main` before SlangPy CI builds. Empty
+  # means "no cherry-pick": every run tests against SlangPy `main` as-is, which is the
+  # normal state.
+  #
+  # A Slang change that breaks SlangPy is a chicken-and-egg problem: until the matching
+  # SlangPy PR lands, every Slang PR fails SlangPy CI. Setting this to that PR's number
+  # asks SlangPy CI to merge it in before building, so both halves are tested together.
+  # SlangPy CI owns the checkout (see ci-latest-slang.yml in shader-slang/slangpy).
+  #
+  # Setting this applies to every Slang PR, so keep the window short: land the SlangPy
+  # PR right after the Slang one, then set this back to "".
+  SLANGPY_CHERRY_PICK_PR: ""
+
 jobs:
   filter:
     runs-on: ubuntu-latest
@@ -165,9 +179,17 @@ jobs:
                 slang_ref: `${{ steps.pr_mq.outputs.ref || steps.pr_auto.outputs.sha || steps.pr_manual.outputs.sha }}`,
                 slang_checkout_mode: `${{ steps.pr_mq.outputs.checkout_mode }}` || 'pr',
                 slang_checkout_repo: `${{ steps.pr_mq.outputs.checkout_repo }}` || '${{ github.repository }}',
-                is_fork_pr: `${{ steps.pr_auto.outputs.is_fork_pr || steps.pr_manual.outputs.is_fork_pr || steps.pr_mq.outputs.is_fork_pr }}`,
-                slang_pr_head_repo: `${{ steps.pr_auto.outputs.head_repo || steps.pr_manual.outputs.head_repo || steps.pr_mq.outputs.head_repo }}`,
-                slang_trigger_source: '${{ github.event_name }}',
+                // `client_payload` is capped at 10 top-level properties by the
+                // repository-dispatch API, and the flat form was already at 10. These
+                // three are informational only -- SlangPy CI reads none of them -- so
+                // they are grouped here to keep the cap free for fields SlangPy acts
+                // on. Nesting does not count against the cap.
+                slang_pr_meta: {
+                  is_fork_pr: `${{ steps.pr_auto.outputs.is_fork_pr || steps.pr_manual.outputs.is_fork_pr || steps.pr_mq.outputs.is_fork_pr }}`,
+                  slang_pr_head_repo: `${{ steps.pr_auto.outputs.head_repo || steps.pr_manual.outputs.head_repo || steps.pr_mq.outputs.head_repo }}`,
+                  slang_trigger_source: '${{ github.event_name }}'
+                },
+                slangpy_cherry_pick_pr: process.env.SLANGPY_CHERRY_PICK_PR || '',
                 slang_pr_title: process.env.PR_TITLE || '',
                 slang_pr_author: `${{ steps.pr_auto.outputs.author || steps.pr_manual.outputs.author || steps.pr_mq.outputs.author }}`
               }


### PR DESCRIPTION
## Motivation

A Slang change that intentionally breaks SlangPy cannot be landed together with its
SlangPy counterpart, which leaves a chicken-and-egg problem:

- Before the Slang change lands, the SlangPy fix does not compile, because the new
  Slang feature does not exist yet.
- After it lands, SlangPy `main` no longer compiles against Slang `master`, so
  **every** Slang PR fails the `SlangPy Tests` check until the SlangPy fix merges.

shader-slang/slang#12840 is a concrete instance: it retypes the layout parameter of
`matrix` from `int` to a new `MatrixLayoutMode` enum, which SlangPy declares as `int`
in two places.

## Proposed solution

Give Slang CI a way to name a SlangPy PR that SlangPy CI should merge into `main` for
the duration of a run, so both halves of a coordinated change are tested together
before either lands.

`ci-slangpy-trigger-test.yml` never checks out SlangPy — it only fires a
`repository_dispatch` at `shader-slang/slangpy`, and the SlangPy working tree comes
from `actions/checkout` in SlangPy's own `ci-latest-slang.yml`. So this repository can
only supply the PR number; SlangPy CI owns the checkout. The consuming half already
merged as shader-slang/slangpy#1143.

**This PR ships the variable empty**, so merging it changes no behavior: the payload
carries an empty field and SlangPy CI keeps testing against SlangPy `main` exactly as
it does today.

Actually setting it for #12840 is a separate one-line PR, #12981, so that the
temporary pin and this permanent infrastructure can be reviewed, landed, and reverted
independently. This PR is the durable half and does not need reverting.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/ci-slangpy-trigger-test.yml` | Adds the empty `SLANGPY_CHERRY_PICK_PR` variable, forwards it as `slangpy_cherry_pick_pr` in the dispatch payload, and groups three unused payload fields under `slang_pr_meta` to stay within the payload cap. |

## Landing order

This is step 1 of a coordinated sequence; the rest is listed here so a reviewer can see
where this PR sits:

1. **this PR** — the mechanism, ships empty, safe to land at any time
2. shader-slang/slangpy#1145 — fixes the Windows half of the SlangPy step
3. #12981 — sets `SLANGPY_CHERRY_PICK_PR` to `1135`
4. #12840 — the breaking Slang change
5. shader-slang/slangpy#1135 — the matching SlangPy fix
6. revert #12981

## Concepts and vocabulary

- **`repository_dispatch`** — the cross-repository trigger this workflow uses to start
  SlangPy CI. It always runs on the *target* repository's default branch, which is why
  SlangPy CI cannot learn which PR to merge unless the dispatcher tells it.
- **`client_payload`** — the JSON blob carried by that dispatch. Capped by the GitHub
  API at 10 top-level properties and 64KB total.

## Process report

**Why the payload had to be restructured.** Adding a field to `client_payload` failed
outright:

```
HTTP 422: No more than 10 properties are allowed; 11 were supplied.
```

The payload was already at exactly 10 top-level properties, so *any* new field would
have been rejected and the dispatch never created — meaning `SlangPy Tests` would fail
on every Slang PR. `is_fork_pr`, `slang_pr_head_repo`, and `slang_trigger_source` are
read zero times by SlangPy CI, so they are grouped under a single `slang_pr_meta`
object. The cap counts top-level properties only, so nesting keeps the values
available for debugging while leaving a free slot. Nothing is dropped and no consumer
observes the move.

**Why `|| ''` rather than omitting the field.** `process.env.SLANGPY_CHERRY_PICK_PR`
is `undefined` when the variable is empty, and the payload would then carry
`undefined`. Sending an explicit empty string keeps the payload shape stable, and the
SlangPy side treats empty and absent identically — its step guard is a truthiness
check. That matters because Slang `master` and SlangPy `main` update independently.

**Validation.** The mechanism was exercised end to end before this was split out, by
dispatching the workflow from a branch (`workflow_dispatch` reads the workflow from
the given ref, unlike `pull_request_target`, which reads it from the base branch — so
this PR cannot test itself). With the variable set to `1135`, SlangPy CI reported:

```
##[notice]Merged SlangPy PR #1135 into main for this run
260 | __generic<T : IPrintable, let R : int, let C : int, let L : MatrixLayoutMode>
    |                                                             ^^^^^^^^^^^^^^^^ undefined identifier 'MatrixLayoutMode'.
```

which is the expected outcome: SlangPy#1135's code was merged in and compiled against
a Slang that does not yet have the enum. That run also exposed a Windows-only bug in
the SlangPy step, fixed separately in shader-slang/slangpy#1145.

