### PR TITLE
Fix assertion in legalizeMakeStruct pair case for none-flavored args

### DIFF
--- a/source/slang/slang-ir-legalize-types.cpp
+++ b/source/slang/slang-ir-legalize-types.cpp
@@ -1679,6 +1679,16 @@ static LegalVal legalizeMakeStruct(
                     ordinaryArgs.add(argPair->ordinaryVal);
                     specialArgs.add(argPair->specialVal);
                 }
+                else if (arg.flavor == LegalVal::Flavor::none)
+                {
+                    // The argument has been legalized to nothing (e.g. the
+                    // value-producing instruction was eliminated). Distribute
+                    // a none value to whichever sides expect this field.
+                    if (ee.flags & Slang::PairInfo::kFlag_hasOrdinary)
+                        ordinaryArgs.add(arg);
+                    if (ee.flags & Slang::PairInfo::kFlag_hasSpecial)
+                        specialArgs.add(arg);
+                }
                 else if (ee.flags & Slang::PairInfo::kFlag_hasOrdinary)
                 {
                     ordinaryArgs.add(arg);

--- a/tests/bugs/nested-struct-metal-assert.slang
+++ b/tests/bugs/nested-struct-metal-assert.slang
@@ -1,0 +1,58 @@
+// Test that nested differentiable struct instances with mixed resource/value
+// fields compile correctly for Metal target.
+// Regression test for assertion failure in type legalization (PR #9808).
+
+//TEST:SIMPLE(filecheck=CHECK): -target metal -stage compute -entry main
+
+struct Material : IDifferentiable {
+    float3 color;
+    float3 emission;
+
+    [Differentiable]
+    __init() {
+        color = float3(1, 1, 1);
+        emission = float3(0, 0, 0);
+    }
+};
+
+struct Particle : IDifferentiable {
+    float2 position;
+    float2 velocity;
+    float size;
+    Material material;
+
+    [Differentiable]
+    __init(float2 pos, float2 vel) {
+        this.position = pos;
+        this.velocity = vel;
+        this.material = Material();
+        this.size = 0.5;
+    }
+};
+
+void storeParticle(
+    RWStructuredBuffer<float2> positions,
+    RWStructuredBuffer<float2> velocities,
+    RWStructuredBuffer<float> sizes,
+    RWStructuredBuffer<Material> materials,
+    uint idx,
+    Particle p)
+{
+    positions[idx] = p.position;
+    velocities[idx] = p.velocity;
+    sizes[idx] = p.size;
+    materials[idx] = p.material;
+}
+
+// CHECK: main
+[numthreads(1, 1, 1)]
+void main(
+    uniform RWStructuredBuffer<float2> positions,
+    uniform RWStructuredBuffer<float2> velocities,
+    uniform RWStructuredBuffer<float> sizes,
+    uniform RWStructuredBuffer<Material> materials,
+    uint3 tid : SV_DispatchThreadID)
+{
+    Particle p = Particle(float2(1, 2), float2(3, 4));
+    storeParticle(positions, velocities, sizes, materials, tid.x, p);
+}


### PR DESCRIPTION
## Motivation

When a `MakeStruct` operand is legalized to none (e.g. because the value-producing instruction was eliminated during type legalization), the pair case in `legalizeMakeStruct` only added it to the ordinary side if the field had both ordinary and special flags. This caused a count mismatch when recursing into the special tuple, triggering an assertion failure (`argIndex < argCount`).

This surfaced as a SlangPy nightly CI failure on macOS Debug (Metal target).

## Proposed solution

Explicitly handle none-flavored args before the flag-based branches, distributing the none value to whichever sides expect the field.

## Change summary

- `source/slang/slang-ir-legalize-types.cpp`: handle none-flavored args in the pair case of `legalizeMakeStruct`.
- `tests/bugs/nested-struct-metal-assert.slang`: regression test.

## Process report

Opening as draft for review — parked without a PR since 2026-04-02; revisiting now during worktree cleanup.