### PR TITLE
agentic tests: sync expected-failures with nightly run 34310111817

### DIFF
--- a/docs/generated/tests/_meta/expected-failures.txt
+++ b/docs/generated/tests/_meta/expected-failures.txt
@@ -34,22 +34,6 @@
 # Not for: untracked flakes or anything that would otherwise be silently
 # silenced. Every entry needs a comment block above it explaining why.
 
-# https://github.com/shader-slang/slang/issues/11375 — slangi VM
-# "operand access out of bounds in constants section" on the second
-# `printf` after a function call that took an `inout` parameter and
-# returned `bool`. Predates PR #11221.
-docs/generated/tests/design/ast-reference/expressions/logic-and-short-circuit.slang
-docs/generated/tests/design/ast-reference/expressions/logic-or-short-circuit.slang
-docs/generated/tests/design/ast-reference/expressions/bwd-differentiate-expr.slang
-docs/generated/tests/design/ast-reference/statements/ifstmt-predicate-evaluated-once.slang
-
-# https://github.com/shader-slang/slang/issues/11402 — slangi VM
-# treats the bool `false` literal as `true` inside a function body
-# when passed as a bool argument. Frontend HLSL/CPU emit are correct,
-# so the bug is in the bytecode VM. Discovered while writing the
-# language-reference/expressions-literal bundle.
-docs/generated/tests/conformance/expressions-literal/bool-true-false.slang
-
 # https://github.com/shader-slang/slang/issues/11403 — slangi VM
 # short-circuits `?:` contra the language-reference spec. The HLSL
 # emit shows both branches; the VM evaluates only the selected
@@ -107,22 +91,17 @@ docs/generated/tests/design/ast-reference/expressions/countof-static-array.slang
 docs/generated/tests/design/ir-reference/misc/countof-fixed-size-array.slang (cpu)
 
 # Pending: docs/generated/tests/_meta/findings/new-expr-with-constructor-args-internal-error.yaml
-# `new T(args)` on a class that declares a matching `__init` aborts with
-# `E99997 ... InternalError ... could not resolve target declaration for
-# call` on every target tried (hlsl, cpp, host-cpp, spirv-asm, slangi).
-# The zero-argument `new T()` form compiles. (Will become a tracking issue
-# after human triage.)
-# The emission fan-out added glsl/spirv-asm/metal/wgsl directives to the same
-# file, and the abort is not target-specific, so every sub-test fails too.
-# NOTE: `lint_expected_failures` resolves each entry as a path on disk, so it
-# flags the `<file>.<n>` sub-test names as unresolvable; the lint rule does not
-# yet know about slang-test's sub-test naming. Remove the whole block when the
-# abort is fixed.
-docs/generated/tests/design/ast-reference/expressions/new-expr-constructor-args.slang
+# The `E99997 ... could not resolve target declaration for call` abort this
+# block was opened for is fixed by
+# https://github.com/shader-slang/slang/pull/12519, so the hlsl (`.slang`),
+# metal (`.slang.3`) and wgsl (`.slang.4`) directives now pass and have been
+# removed from this block. What remains is the separate emission gap #12519
+# called out: a class object materialized in a shader still fails to emit on
+# the Khronos targets, so glsl (`.slang.1`) reports `E99999 ... unhandled
+# type` and spirv-asm (`.slang.2`) reports `E99997 ... Unhandled global inst
+# in spirv-emit`. Remove these two once class emission works there.
 docs/generated/tests/design/ast-reference/expressions/new-expr-constructor-args.slang.1
 docs/generated/tests/design/ast-reference/expressions/new-expr-constructor-args.slang.2
-docs/generated/tests/design/ast-reference/expressions/new-expr-constructor-args.slang.3
-docs/generated/tests/design/ast-reference/expressions/new-expr-constructor-args.slang.4
 
 # Pending: docs/generated/tests/_meta/findings/switch-case-decl-used-in-later-case-invalid-cpp-emit.yaml
 # A local declared under one `switch` case label and used under another is
@@ -131,14 +110,6 @@ docs/generated/tests/design/ast-reference/expressions/new-expr-constructor-args.
 # undeclared `shared_0`, so clang rejects the generated file. (Will become
 # a tracking issue after human triage.)
 docs/generated/tests/design/ast-reference/statements/switchstmt-case-decl-used-in-later-case.slang (cpu)
-
-# Pending: docs/generated/tests/_meta/findings/slangi-vm-narrow-int-return-not-sign-extended.yaml
-# Under slangi, a negative `int8_t` / `int16_t` value returned from a
-# function comes back zero-extended: `int8_t f() { return int8_t(-128); }`
-# prints 128 instead of -128, while the same constant read directly (or
-# emitted for `-target cpp`) keeps its sign. (Will become a tracking issue
-# after human triage.)
-docs/generated/tests/design/cross-cutting/core-module/core-int8-min-return-boundary.slang
 
 # Pending: docs/generated/tests/_meta/findings/metal-append-buffer-params-missing-binding-slot.yaml
 # On `-target metal` the element and counter pointers that
@@ -173,3 +144,57 @@ docs/generated/tests/design/ast-reference/declarations/refaccessor-property.slan
 # compiles in an ordinary expression. Recorded in
 # _meta/findings/enum-cast-in-generic-array-bound-rejected.yaml.
 docs/generated/tests/design/ast-reference/values/builtinoperationintval-enum-operands-fold.slang
+
+# Surfaced on nightly run 34310111817 (first failed on the 2026-09-02
+# nightly and every nightly since):
+# https://github.com/shader-slang/slang/actions/runs/34310111817
+# Compiler bug, bisected to
+# https://github.com/shader-slang/slang/pull/12574. `prelinkIR` now clones
+# an imported interface's definition into the user module instead of
+# re-deriving it. `builtinRequirementKey` is hoistable, so the linker's
+# cloner (`cloneInst` in slang-ir-link.cpp) dedups the cloned key onto the
+# one lowering already created — and then runs `cloneDecorationsAndChildren`
+# on that pre-existing inst anyway, so it ends up with
+# `BuiltinRequirementDecoration` twice. slang-ir-clone.cpp guards against
+# exactly this case (see PR #12569); the linker's cloner has no equivalent
+# guard. All three tests pin "the role decoration is immediately followed by
+# the key built from the same ordinal", which the duplicated line breaks.
+# Remove once the linker stops grafting decorations onto a dedup hit.
+docs/generated/tests/design/cross-cutting/ir-instructions/decoration-builtin-requirement-key-ir.slang
+docs/generated/tests/design/ir-reference/decorations/builtin-requirement-key-decoration.slang
+docs/generated/tests/design/ir-reference/differentiation/builtin-requirement-decoration.slang
+
+# Surfaced on nightly run 34310111817:
+# https://github.com/shader-slang/slang/actions/runs/34310111817
+# Test bug rather than a compiler bug. `//CHECK: new C` used to match only
+# because the compiler aborted on `new C(7)` and the `E99997` note echoed the
+# offending source line `C a = new C(7);` back into the output.
+# https://github.com/shader-slang/slang/pull/12519 fixed that abort, so the
+# file compiles — and since `a` is never read, DCE drops the allocation and
+# the emitted C++ entry point body is empty, so nothing can match. Remove
+# once the bundle is regenerated with an observation point that keeps the
+# allocation live (for example storing `a.v` into a buffer).
+docs/generated/tests/design/ast-reference/declarations/classdecl-reference-type.slang
+
+# Surfaced on nightly run 34310111817:
+# https://github.com/shader-slang/slang/actions/runs/34310111817
+# Obsolete test. https://github.com/shader-slang/slang/pull/12182 added
+# CUDA/OptiX callable support, so
+# `CUDALayoutRulesFamilyImpl::getCallablePayloadParameterRules()` returns
+# real rules and the `E39032` rejection this test asserts no longer happens;
+# the entry point now emits as `__direct_callable__main_0`. The doc the test
+# is anchored to went stale the same way — docs/generated/design/pipeline/
+# 04c-layout-ir.md still lists CUDA as returning `nullptr` from that
+# accessor. Remove once that doc and this bundle are regenerated.
+docs/generated/tests/design/pipeline/04c-layout-ir/raytracing-callable-payload-rejected-on-cuda.slang
+
+# Surfaced on nightly run 34310111817:
+# https://github.com/shader-slang/slang/actions/runs/34310111817
+# Diagnostic text drift rather than a compiler bug.
+# https://github.com/shader-slang/slang/pull/12616 merges type-flow sets
+# directly instead of through an intermediate hash set, so `E50102` now
+# reports "2 possible types: 'Square, Rect'" where the pinned text says
+# "'Rect, Square'". Remove once the expected text is regenerated — or once
+# the diagnostic sorts the list, which would make the text order-stable by
+# construction rather than a reflection of the merge order.
+docs/generated/tests/design/pipeline/05-ir-passes/typeflow-report-dynamic-dispatch-sites.slang


### PR DESCRIPTION
## Motivation

The nightly agentic test suite has failed with the same six unexpected failures every night since 2026-09-02. The last green run was [2026-09-01](https://github.com/shader-slang/slang/actions/runs/33469027637) at `0a740e4df`; the most recent failure is [run 34310111817](https://github.com/shader-slang/slang/actions/runs/34310111817) at `ff22f4b10`.

```
6 failing tests:
---
docs/generated/tests/design/ast-reference/declarations/classdecl-reference-type.slang
docs/generated/tests/design/cross-cutting/ir-instructions/decoration-builtin-requirement-key-ir.slang
docs/generated/tests/design/ir-reference/decorations/builtin-requirement-key-decoration.slang
docs/generated/tests/design/ir-reference/differentiation/builtin-requirement-decoration.slang
docs/generated/tests/design/pipeline/04c-layout-ir/raytracing-callable-payload-rejected-on-cuda.slang
docs/generated/tests/design/pipeline/05-ir-passes/typeflow-report-dynamic-dispatch-sites.slang
```

All six regressed inside the 23-commit window `0a740e4df..1c2e5d2a9`, and none were caught by PR CI, because this suite only runs nightly. The same run also reported nine entries in `expected-failures.txt` that have started passing, which is the file's own cue to remove them.

A red nightly that stays red stops being a signal, so this PR restores the suite to green and records what each entry is waiting on.

## Proposed solution

Bisect each failure to the commit that caused it, then use the mechanism the suite already has for this: `_meta/expected-failures.txt`, which `slang-test -expected-failure-list` reclassifies as `failed(expected)` and keeps out of the exit code.

The file's header requires every entry to carry a comment documenting *why* it exists, so that it is removable when the cause is fixed. Each block added here names the causing PR, the mechanism, and the condition under which the entry should be deleted again — so none of these is silent silencing.

I built `slangc`, `slangi` and `slang-test` at six commits to attribute the failures rather than guess: `0a740e4df`, `6d01f9f15^`, `6d01f9f15`, `4cf253d0c^`, `4cf253d0c`, and the nightly's own `ff22f4b10`.

## Change summary

| Area | What changes |
| --- | --- |
| `docs/generated/tests/_meta/expected-failures.txt` | Adds four comment blocks covering the six newly-skipped tests; removes three whole blocks and three entries from a fourth for the nine tests that now pass; rewrites the `new-expr-constructor-args` block to describe what is left of that bug |

No compiler, test, or CI-workflow source is touched.

### Added (6)

| Test(s) | Cause |
| --- | --- |
| `decoration-builtin-requirement-key-ir`, `builtin-requirement-key-decoration`, `builtin-requirement-decoration` | Compiler bug from #12574 — duplicate `BuiltinRequirementDecoration` |
| `classdecl-reference-type` | Test bug, unmasked by #12519 |
| `raytracing-callable-payload-rejected-on-cuda` | Obsolete after #12182; its design doc is stale too |
| `typeflow-report-dynamic-dispatch-sites` | Diagnostic text drift from #12616 |

### Removed (9)

| Entry | Why |
| --- | --- |
| `logic-and-short-circuit`, `logic-or-short-circuit`, `bwd-differentiate-expr`, `ifstmt-predicate-evaluated-once` | #11375 block, all four pass |
| `bool-true-false` | #11402 block, passes |
| `core-int8-min-return-boundary` | `slangi-vm-narrow-int-return-not-sign-extended` finding, passes |
| `new-expr-constructor-args.slang`, `.slang.3`, `.slang.4` | hlsl/metal/wgsl, fixed by #12519 |

`new-expr-constructor-args.slang.1` (glsl) and `.slang.2` (spirv-asm) stay: #12519 explicitly called out that a class object materialized in a shader still fails to emit on the Khronos targets, and that gap is untouched.

## Concepts and vocabulary

- **Agentic test suite** — the doc-anchored bundles under `docs/generated/tests/`. It runs only in the `Nightly Slang Test` workflow, not in PR CI, which is why a regression here can survive several days.
- **`expected-failures.txt`** — the suite's own known-failing list, deliberately *not* shared with `tests/expected-failure-*.txt`. `slang-test` reclassifies a listed failure as `failed(expected)` and, symmetrically, prints a `passing tests that are expected to fail` section when a listed entry starts passing.
- **Sub-test name** — `slang-test` names the Nth `//TEST` directive in a file `<file>.slang.N`, with the first directive keeping the bare file name. An entry can therefore target one target's directive rather than the whole file, which is what the `new-expr-constructor-args` split relies on.
- **Hoistable inst** — an IR instruction whose identity is its op plus operands, so constructing "another one" returns the existing inst. `builtinRequirementKey` is hoistable, keyed on the requirement-kind ordinal; that is what makes the duplicate-decoration bug below possible.

## Process report

### The three `builtinRequirementKey` tests — a real compiler bug

At `ff22f4b10` the very first `### LOWER-TO-IR:` dump shows every builtin requirement key tagged twice:

```
[BuiltinRequirementDecoration(25 : Int)]
[BuiltinRequirementDecoration(25 : Int)]
let %1 : _ = builtinRequirementKey(25 : Int)
```

At `0a740e4df` there is exactly one such line per key. Bisecting: `4cf253d0c` (#12574) shows the duplicate; its parent `6d01f9f15` does not.

The trace. `getInterfaceRequirementKey` in `slang-lower-to-ir.cpp` builds the key with `getBuiltinRequirementKey(kind)` and guards its own tagging, exactly as its comment says — "The key is shared, so add the decoration only once":

```cpp
requirementKey = builder->getBuiltinRequirementKey((IRIntegerValue)builtinRole);
context->shared->interfaceRequirementKeys.add(requirementDecl, requirementKey);
if (!requirementKey->findDecoration<IRBuiltinRequirementDecoration>())
    builder->addBuiltinRequirementDecoration(requirementKey, (IRIntegerValue)builtinRole);
```

That guard is not the site that breaks. #12574 introduced `tryBorrowInterfaceFromOwningModule`, so an interface owned by another module — `IDifferentiable` here — is now borrowed and its real definition supplied by `prelinkIR` at the end of lowering, instead of being re-derived locally. `prelinkIR` therefore clones the core module's interface, including the `builtinRequirementKey` insts it references, into the user module. In `cloneInst` (`slang-ir-link.cpp`) the clone goes through `createIntrinsicInst`, which for a hoistable op returns the key the local lowering already created, and then the code unconditionally runs `cloneDecorationsAndChildren` on that pre-existing inst. So the decoration lands a second time on an inst that already had it.

This is the same failure mode `slang-ir-clone.cpp` already defends against, added by #12569:

```cpp
// `cloneInstAndOperands` may also return a *different*, pre-existing
// hoistable inst via global value numbering ... That inst is already fully
// populated, so grafting `oldInst`'s children onto it here would add a
// duplicate, unrelated entry instead of merging anything.
if (getIROpInfo(newInst->getOp()).isHoistable() && newInst->getFirstDecorationOrChild())
    return newInst;
```

The linker's cloner has no equivalent guard. Before #12574 it never had to clone a builtin requirement key into a module that already had one, so the gap was unreachable.

On the input-shape question: the shape the tests observe is *not* correct and should not be accommodated. A hoistable key deduplicated on its kind ordinal is supposed to carry exactly one role tag; two copies is a second, divergent spelling of one logical value. Consumers such as autodiff's `getInterfaceEntryByBuiltinRequirement` read it through `findDecoration`, which returns the first, so nothing misbehaves today — but the tests are right to pin it, and the fix belongs in the linker's cloner (or in a shared guard both cloners use), not in the tests. That is why this entry is filed as a compiler bug awaiting a fix rather than as a test to regenerate.

### `classdecl-reference-type` — a test that was passing for the wrong reason

The test asserts that a class allocates with `new`:

```slang
//TEST:SIMPLE(filecheck=CHECK):-target cpp -entry main -stage compute
class C { int v; __init(int x) { v = x; } }
[shader("compute")] [numthreads(1,1,1)]
void main()
{
    //CHECK: new C
    C a = new C(7);
}
```

Built at `0a740e4df`, that invocation does not emit C++ at all:

```
classdecl-reference-type.slang(30): note 99999: an internal error threw an exception ...
    C a = new C(7);
      ^
error[E99997]: ... could not resolve target declaration for call
```

`//CHECK: new C` was matching the **source line the crash note echoes back**, not emitted code. This is the abort #12485 describes, and `new-expr-constructor-args.slang` was already on the expected-failures list for it — this file simply hid it behind a coincidental match.

#12519 fixed that abort, so at `ff22f4b10` the file compiles cleanly and the emitted entry point is:

```cpp
void _main_0(void* _S1, void* entryPointParams_0, void* _S2)
{
    return;
}
```

`a` is never read, so the allocation is dead and DCE removes it. The CHECK can no longer match anything, and it should not: the test needs an observation point that keeps the allocation live, such as storing `a.v` into a buffer. That is a bundle regeneration, not a compiler change, which is what the comment block asks for.

### `raytracing-callable-payload-rejected-on-cuda` — obsolete test, and a stale doc

The test asserts that a `callable` entry point's payload is rejected with `E39032` on CUDA, because the CUDA layout-rules family was documented as returning `nullptr` from `getCallablePayloadParameterRules` alone. #12182 added CUDA/OptiX callable support and introduced `kCUDACallablePayloadParameterLayoutRulesImpl_` (`git log -S` over `slang-type-layout.cpp` points at exactly that commit), so the accessor now returns real rules. At `ff22f4b10` the same input compiles:

```cpp
extern "C" __device__ void __direct_callable__main_0(CallData_0 * p_0)
```

The claim the test is anchored to went stale in the same commit — `docs/generated/design/pipeline/04c-layout-ir.md` still says "the CUDA family [returns `nullptr`] from `getCallablePayloadParameterRules` alone". Fixing that means regenerating the doc section and the bundle together, which is out of scope here; the comment block records both halves so whoever regenerates the doc knows to drop the entry with it.

### `typeflow-report-dynamic-dispatch-sites` — diagnostic text drift

The test pins the `-report-dynamic-dispatch-sites` note:

```
generated dynamic dispatch code for this site. 2 possible types: 'Rect, Square'
```

Built at `6d01f9f15^` I get `'Rect, Square'`; at `6d01f9f15` (#12616) I get `'Square, Rect'`. That PR replaced an intermediate hash set with a direct merge of the type-flow sets, and the old text was a reflection of that hash set's iteration order. The new order is deterministic, so the pinned text simply needs regenerating.

Worth noting for whoever picks it up: the diagnostic's order is incidental either way. Sorting the list at the emission site would make the text order-stable by construction and immune to the next merge-strategy change, which is why the comment offers that as the alternative removal condition.

### The nine removals

The run's `passing tests that are expected to fail` section is the authoritative list, but one entry deserved a second look: `core-int8-min-return-boundary` failed on the 2026-09-08 nightly and passed on 2026-09-09, which reads like flakiness. I ran all six `slangi` entries individually against the `ff22f4b10` build rather than trusting the summary, and each produces exactly its CHECK text — `core-int8-min-return-boundary` prints `direct=-128 returned=-128`, so the sign-extension bug behind that finding is genuinely gone, not intermittently hidden.

For `new-expr-constructor-args` I ran all five targets rather than removing the block wholesale:

| target | directive | result at `ff22f4b10` |
| --- | --- | --- |
| hlsl | `.slang` | passes |
| glsl | `.slang.1` | `error[E99999]` |
| spirv-asm | `.slang.2` | `error[E99997]` |
| metal | `.slang.3` | passes |
| wgsl | `.slang.4` | passes |

which is precisely the split #12519 predicted, so the two Khronos entries stay and the comment now describes that remaining gap instead of the fixed abort. While rewriting the comment I also dropped its `NOTE` claiming the lint cannot resolve `<file>.<n>` names — `lint_expected_failures` strips both the `.N` index and a trailing ` (config)` suffix before resolving, so the note was describing a limitation that no longer exists.

### Verification

Against a local build at the nightly's own commit `ff22f4b10`, with this branch's `expected-failures.txt`:

- The six additions all report `failed(expected)`, `slang-test` exits **0**, and the unexpected-pass section is empty.
- The nine removals all report `passed`; `.slang.1` and `.slang.2` still report `failed(expected)`.
- `regenerate.py lint` reports **0 errors, 305 warnings** — byte-identical to the pre-change baseline and to the lint step of run 34310111817 itself.

`.txt` files are not covered by `extras/formatting.sh` (it matches `CMakeLists.txt` only), so there is no formatting delta.

### Follow-ups this PR deliberately does not do

Scoped to restoring the nightly signal:

- No tracking issue is filed for the #12574 duplicate-decoration bug; the entry references the PR and the run.
- The `_meta/findings/*.yaml` entries behind the removed blocks (`slangi-vm-narrow-int-return-not-sign-extended`, and the now partly-resolved `new-expr-with-constructor-args-internal-error`) are still open and would normally be retired via `regenerate.py findings`.
- The stale `04c-layout-ir.md` claim about CUDA callable payload rules is left for the doc regeneration that will also drop that entry.
