### PR TITLE
ci: pass Sprint iteration ids as GraphQL String

### DIFF
--- a/.github/scripts/issue-onboard.test.js
+++ b/.github/scripts/issue-onboard.test.js
@@ -3,6 +3,8 @@
 "use strict";
 
 const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
 const extractor = require("./extract-workflow-js.js");
 const { currentIteration } = extractor.load({
   workflow: ".github/workflows/issue-board-onboard.yml",
@@ -75,6 +77,18 @@ test("currentIteration: accepts a Date", () => {
     currentIteration([SPRINT_61], new Date("2026-08-25T12:00:00Z")).title,
     "Sprint 61",
   );
+});
+
+test("setIteration declares iterationId as String, not ID", () => {
+  const yaml = fs.readFileSync(
+    path.join(__dirname, "..", "workflows", "issue-board-onboard.yml"),
+    "utf8",
+  );
+  const mutations = [...yaml.matchAll(/mutation\([^)]+\)/g)].map((m) => m[0]);
+  const sprint = mutations.find((m) => m.includes("$iteration"));
+  assert.ok(sprint, "expected a mutation that takes $iteration");
+  assert.match(sprint, /\$iteration: String!/);
+  assert.doesNotMatch(sprint, /\$iteration: ID!/);
 });
 
 (async () => {

--- a/.github/workflows/issue-board-onboard.yml
+++ b/.github/workflows/issue-board-onboard.yml
@@ -474,6 +474,8 @@ jobs:
               console.log(`set ${fieldName} = ${optionName}`);
             }
 
+            // iterationId is String, like singleSelectOptionId above: GitHub
+            // iteration ids are opaque hex, not GraphQL global IDs.
             async function setIteration(itemId, fieldName, iteration) {
               if (!itemId || !iteration?.id) return;
               const f = await field(fieldName);
@@ -482,7 +484,7 @@ jobs:
                 return;
               }
               await github.graphql(`
-                mutation($project: ID!, $item: ID!, $field: ID!, $iteration: ID!) {
+                mutation($project: ID!, $item: ID!, $field: ID!, $iteration: String!) {
                   updateProjectV2ItemFieldValue(input: {
                     projectId: $project, itemId: $item, fieldId: $field,
                     value: { iterationId: $iteration }


### PR DESCRIPTION
## Motivation

Internal issues opened onto Slang-All were landing in **In Triage** with **Sprint** empty. The onboard workflow uses `SLANG_PR_BOT_TOKEN` (the org Projects PAT, not `GITHUB_TOKEN`) and was getting far enough to add the card, set Source, assign the author, and set Status. It then failed on the Sprint write.

Consider issue [#12979](https://github.com/shader-slang/slang/issues/12979). [Issue Onboard run 34332457741](https://github.com/shader-slang/slang/actions/runs/34332457741) classified `skiminki-nv` as Internal, added the card, set Status to In Triage, then died with:

```
Type mismatch on variable $iteration and argument iterationId (ID! / String)
```

The mutation declared `$iteration: ID!` and passed `a9562d51`. That value is the live Sprint 62 iteration id on org project 10. The same failure has been hitting other recent Internal onboard runs.

## Proposed solution

Declare `$iteration` as `String!`, matching `ProjectV2FieldValue.iterationId` and matching how this same script already passes `singleSelectOptionId`.

GitHub iteration ids are opaque hex strings from `ProjectV2IterationFieldIteration.id` (`String!`), not GraphQL global IDs. The workflow already reads `configuration.iterations { id … }` and passes `iteration.id` unchanged. That content is correct; only the variable type was wrong. Live schema introspection on `api.github.com` confirms `iterationId: String`.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/issue-board-onboard.yml` | `$iteration: ID!` → `$iteration: String!` on the Sprint mutation; short comment why |
| `.github/scripts/issue-onboard.test.js` | Assert the Sprint mutation takes `$iteration: String!` and not `ID!` |

## Concepts and vocabulary

- **Slang-All** — org Projects V2 board (`PVT_kwDOAb2kZs4AcYVs`) that issue-onboard writes.
- **Issue onboard** — `issues: opened` caller plus `issue-board-onboard.yml`. For Internal authors it assigns the opener, sets Status to In Triage, and sets Sprint to the iteration whose `[startDate, startDate+duration)` window contains now.
- **`iterationId` vs field `id`** — `fieldId` is the Sprint field's node id (`PVTIF_…`, GraphQL `ID`). `iterationId` is `configuration.iterations[].id` (hex like `a9562d51`, GraphQL `String`). There is no encoding step between the query and the mutation.

## Process report

The missing Sprint was not a token problem and not a missing “whenever Status becomes In Triage” hook. Onboard already sets Sprint in the same Internal path as In Triage, using `SLANG_PR_BOT_TOKEN`. For #12979 that path ran with `HAS_TOKEN: true` and succeeded through `set Status = In Triage`.

`setIteration` then called `updateProjectV2ItemFieldValue` with `$iteration: ID!`. GraphQL validates variable types against the input field before applying the value. `iterationId` is `String`, so the request failed and the job aborted after Status was already written. The payload was `field: PVTIF_lADOAb2kZs4AcYVszgSVcrE` and `iteration: a9562d51`, which is the current Sprint 62 id on that board (start 2026-09-01, duration 14). If the string content had been wrong we would have gotten a later “iteration not found” style error; we never got that far.

The input shape here is the canonical one: the same `iterations { id }` GitHub documents for setting an iteration field. The producer (`field("Sprint")` → `currentIteration`) is fine. The consumer declared the wrong GraphQL scalar. Changing `ID!` to `String!` is the layer that owns the bug.

No status-change listener was added. Community/bot issues still do not get a sprint; that is unchanged onboard policy.

**Test plan**

- [x] `node .github/scripts/issue-onboard.test.js` (8 passed)
- [ ] After merge, re-run **Issue Onboard** `workflow_dispatch` with `issue_number=12979` (and any other Internal issues from failed onboard runs) to backfill Sprint