### PR TITLE
ci: source ignored default reviewers from the default-reviewer team

### DIFF
--- a/.github/scripts/pr-assign.test.js
+++ b/.github/scripts/pr-assign.test.js
@@ -125,11 +125,11 @@ test("author shepherd is not auto-requested; top collaborator is suggested", () 
 test("ignored shepherd is not auto-requested; suggestion uses null baseline", () => {
   const { assignee, autoRequestedReviewer, suggestedReviewer } = select(
     [], ["dev2"], {
-      maintainer: "bmillsNV",
-      ignoredReviewers: new Set(["bmillsNV"]),
+      maintainer: "ignoredUser",
+      ignoredReviewers: new Set(["ignoredUser"]),
     });
   // No owners in ranking → maintainer fallback, but ignored → no auto-request.
-  assert.strictEqual(assignee, "bmillsNV");
+  assert.strictEqual(assignee, "ignoredUser");
   assert.strictEqual(autoRequestedReviewer, null);
   assert.strictEqual(suggestedReviewer, "dev2");
 });
@@ -137,7 +137,7 @@ test("ignored shepherd is not auto-requested; suggestion uses null baseline", ()
 test("real existing reviewer clears auto-request but still may suggest", () => {
   const { assignee, autoRequestedReviewer, suggestedReviewer } = select(
     [], ["dev2", "owner1"], {
-      existingReviewers: ["dave"], ignoredReviewers: new Set(["bmillsNV"]),
+      existingReviewers: ["dave"], ignoredReviewers: new Set(["ignoredUser"]),
     });
   assert.strictEqual(assignee, "owner1");
   assert.strictEqual(autoRequestedReviewer, null);
@@ -148,8 +148,8 @@ test("real existing reviewer clears auto-request but still may suggest", () => {
 test("ignored and bot reviewers do not count as existing", () => {
   const { assignee, autoRequestedReviewer, suggestedReviewer } = select(
     [], ["dev2", "owner1"], {
-      existingReviewers: ["bmillsNV", "copilot[bot]"],
-      botAuthors: ["nv-slang-bot"], ignoredReviewers: new Set(["bmillsNV"]),
+      existingReviewers: ["ignoredUser", "copilot[bot]"],
+      botAuthors: ["nv-slang-bot"], ignoredReviewers: new Set(["ignoredUser"]),
     });
   assert.strictEqual(assignee, "owner1");
   assert.strictEqual(autoRequestedReviewer, "owner1");

--- a/.github/workflows/pr-board-sync.md
+++ b/.github/workflows/pr-board-sync.md
@@ -28,7 +28,8 @@ For each open PR the workflow:
 5. Assigns still-unassigned **linked (closing) issues** to the PR owner.
 6. Co-assigns the **community author** on Community PRs (best-effort, after the
    owner is set).
-7. Unrequests **ignored reviewers** (e.g. `bmillsNV`) on onboarding and when
+7. Unrequests **ignored reviewers** (members of `default_reviewer_team`, plus
+   any extra `ignored_reviewers` logins) on onboarding and when
    freshly assigning an owner — not on every sweep pass for already-assigned PRs.
 
 Repo-scoped writes use the run's `GITHUB_TOKEN`, so assignee changes, review
@@ -125,7 +126,7 @@ merge-queued PRs.
    `Scope:` includes this repo — the same criteria used for Source Internal).
 2. Top **committer-signal** owner from changed files (still gated by the owners
    team: `pr-owners` for Community, `bot-pr-owners` for Bot).
-3. Maintainer team member (or `fallback_assignee`).
+3. Maintainer team member, else `default_reviewer_team`, else `fallback_assignee`.
 
 Linked-issue inheritance and committer-signal use different allowlists on
 purpose: an Internal person who owns the issue should shepherd the PR even when
@@ -169,7 +170,8 @@ Consequences worth knowing:
 
 **Community PRs** also co-assign the external author (separate API call, best-effort).
 
-**Ignored reviewers** (`bmillsNV`, …) are unrequested when a new owner is assigned
+**Ignored reviewers** (the `default-reviewer` team, plus any extra configured
+logins) are unrequested when a new owner is assigned
 and on `opened`/`reopened` onboarding. Already-assigned PRs are not re-scanned
 for ignored reviewers on sweep.
 

--- a/.github/workflows/pr-board-sync.yml
+++ b/.github/workflows/pr-board-sync.yml
@@ -15,7 +15,8 @@ name: PR Board Sync (reusable)
 #   - when a PR has an owner, assigns any still-unassigned linked (closing)
 #     issues to that same owner (the PR's primary assignee, not the co-assigned
 #     community author), and
-#   - unrequests auto-assigned reviewers that cannot approve (e.g. bmillsNV).
+#   - unrequests auto-assigned reviewers that cannot approve (members of
+#     default_reviewer_team, plus any extra ignored_reviewers logins).
 #
 # Status state machine (two variants that differ ONLY on a CI failure):
 #   - In Review  - default for an open PR; also re-set whenever a new commit
@@ -164,9 +165,9 @@ on:
         type: string
         default: "nv-slang-bot,slang-coworker-nanoclaw,Copilot,copilot-swe-agent"
       ignored_reviewers:
-        description: "Comma-separated auto-assigned reviewers that cannot approve; unrequested on the PR."
+        description: "Optional extra comma-separated logins to unrequest, in addition to default_reviewer_team members."
         type: string
-        default: "bmillsNV"
+        default: ""
       owners_team:
         description: "org/team-slug whose members may be chosen as a Community PR's assignee/reviewer from the committer-signal ranking (not used for linked-issue inheritance; that uses source_internal_team)."
         type: string
@@ -179,10 +180,14 @@ on:
         description: "org/team-slug tracking the current maintainer(s); the fallback assignee when a non-Internal PR has no linked-issue or committer-signal owner."
         type: string
         default: "shader-slang/slang-maintainer"
-      fallback_assignee:
-        description: "Last-resort assignee for a non-Internal PR when maintainer_team is empty/unset/unreadable and no linked-issue or committer-signal owner is found, so PRs are never left unassigned. Never requested as a reviewer (it is typically an ignored non-approver). Empty disables this fallback (the PR is left to the sweep)."
+      default_reviewer_team:
+        description: "org/team-slug whose members are the repo's default auto-requested reviewers: they are unrequested (they typically cannot approve) and the sorted-first member is the last-resort assignee after maintainer_team."
         type: string
-        default: "bmillsNV"
+        default: "shader-slang/default-reviewer"
+      fallback_assignee:
+        description: "Last-resort assignee for a non-Internal PR when maintainer_team and default_reviewer_team are both empty/unset/unreadable and no linked-issue or committer-signal owner is found, so PRs are never left unassigned. Never requested as a reviewer (it is typically an ignored non-approver). Empty disables this fallback (the PR is left to the sweep)."
+        type: string
+        default: ""
     secrets:
       SLANG_PR_BOT_TOKEN:
         description: "Dedicated bot PAT used for org Projects RW + Members read, repo reads, and as a compatibility fallback for repo writes while callers grant GITHUB_TOKEN Issues/Pull requests write."
@@ -526,6 +531,7 @@ jobs:
 
       # --- Board writes: add + Source + Status (ProjectsV2 PAT) ---------------
       - name: Reconcile board (add, Source, Status)
+        id: reconcile
         if: ${{ env.HAS_TOKEN == 'true' }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
@@ -548,6 +554,7 @@ jobs:
           OWNERS_TEAM: ${{ inputs.owners_team }}
           BOT_OWNERS_TEAM: ${{ inputs.bot_owners_team }}
           MAINTAINER_TEAM: ${{ inputs.maintainer_team }}
+          DEFAULT_REVIEWER_TEAM: ${{ inputs.default_reviewer_team }}
           FALLBACK_ASSIGNEE: ${{ inputs.fallback_assignee }}
           # The run's own GITHUB_TOKEN, used for repo-scoped writes so assignments,
           # review requests, and comments show up as github-actions[bot]. Its reach
@@ -578,6 +585,7 @@ jobs:
             const OWNERS_TEAM = process.env.OWNERS_TEAM || "";
             const BOT_OWNERS_TEAM = process.env.BOT_OWNERS_TEAM || "";
             const MAINTAINER_TEAM = process.env.MAINTAINER_TEAM || "";
+            const DEFAULT_REVIEWER_TEAM = process.env.DEFAULT_REVIEWER_TEAM || "";
             const SOURCE_INTERNAL_TEAM = process.env.SOURCE_INTERNAL_TEAM || "";
             const FALLBACK_ASSIGNEE = process.env.FALLBACK_ASSIGNEE || "";
 
@@ -1456,6 +1464,22 @@ jobs:
               warn: (message) => core.warning(message),
             });
 
+            // default-reviewer team members are the logins repo automation
+            // auto-requests: union them into IGNORED (do not keep them as
+            // reviewers) and use them as last-resort assignee after the
+            // maintainer team.
+            const defaultReviewers = await listTeamMembers(DEFAULT_REVIEWER_TEAM);
+            for (const login of defaultReviewers) {
+              if (login) IGNORED.add(login.toLowerCase());
+            }
+            if (FALLBACK_ASSIGNEE) IGNORED.add(FALLBACK_ASSIGNEE.toLowerCase());
+            if (DEFAULT_REVIEWER_TEAM) {
+              console.log(
+                `default-reviewer team ${DEFAULT_REVIEWER_TEAM}: ` +
+                ([...defaultReviewers].join(", ") || "(empty)"));
+            }
+            core.setOutput("ignored-reviewers", [...IGNORED].join(","));
+
             // Logins with write+ access to this repo (the suggested-reviewer pool).
             // Empty on access error (listing collaborators needs repo admin/push),
             // so the suggestion is simply skipped -- never a hard failure.
@@ -1480,10 +1504,11 @@ jobs:
 
             // The fallback assignee for a non-Internal PR that has no linked-issue
             // or committer-signal owner: the (sorted-first) member of the
-            // maintainer team, else FALLBACK_ASSIGNEE (e.g. bmillsNV) when that
-            // team is unset/empty/unreadable, so a PR is never left unassigned.
-            // Only "" if both are unset, in which case selectAssigneeAndReviewers
-            // yields no pick and we leave it to the sweep. Cached per run.
+            // maintainer team, else of default_reviewer_team, else
+            // FALLBACK_ASSIGNEE when those teams are unset/empty/unreadable, so a
+            // PR is never left unassigned. Only "" if all three are unset, in
+            // which case selectAssigneeAndReviewers yields no pick and we leave
+            // it to the sweep. Cached per run.
             let _maintainer;
             async function resolveMaintainer() {
               if (_maintainer !== undefined) return _maintainer;
@@ -1491,7 +1516,15 @@ jobs:
               if (members.length > 1)
                 core.warning(
                   `maintainer team ${MAINTAINER_TEAM} has ${members.length} members; using ${members[0]}`);
-              _maintainer = members[0] || FALLBACK_ASSIGNEE;
+              if (members[0]) {
+                _maintainer = members[0];
+                return _maintainer;
+              }
+              const defaults = [...defaultReviewers].sort();
+              if (defaults.length > 1)
+                core.warning(
+                  `default-reviewer team ${DEFAULT_REVIEWER_TEAM} has ${defaults.length} members; using ${defaults[0]}`);
+              _maintainer = defaults[0] || FALLBACK_ASSIGNEE;
               return _maintainer;
             }
 
@@ -1717,8 +1750,9 @@ jobs:
                 }
               }
 
-              // Unrequest auto-assigned non-approvers (e.g. bmillsNV), coupled to
-              // assignment exactly as the sweep does.
+              // Unrequest auto-assigned non-approvers (default-reviewer team,
+              // plus ignored_reviewers), coupled to assignment exactly as the
+              // sweep does.
               const toRemove =
                 info.requestedReviewers.filter(r => IGNORED.has(r.toLowerCase()));
               if (toRemove.length) {
@@ -2123,13 +2157,14 @@ jobs:
             }
 
       # --- Unrequest auto-assigned non-approver reviewers --------------------
-      # Runs only at onboarding (opened/reopened) to strip an auto-assigned
-      # non-approver (e.g. bmillsNV) that repo automation requests on a new PR. It
-      # deliberately does NOT run on review_requested, so a maintainer manually
-      # requesting that reviewer is never undone. reconcileAssignment also unrequests
-      # these when it freshly assigns an owner; this onboarding step covers PRs
-      # assignment skips (Source not yet known, a human draft, merge-queued, or no
-      # maintainer resolved). Already-assigned PRs are not re-scanned on sweep.
+      # Runs only at onboarding (opened/reopened) to strip auto-assigned
+      # non-approvers (default-reviewer team, plus ignored_reviewers) that repo
+      # automation requests on a new PR. It deliberately does NOT run on
+      # review_requested, so a maintainer manually requesting that reviewer is
+      # never undone. reconcileAssignment also unrequests these when it freshly
+      # assigns an owner; this onboarding step covers PRs assignment skips
+      # (Source not yet known, a human draft, merge-queued, or no maintainer
+      # resolved). Already-assigned PRs are not re-scanned on sweep.
       - name: Unrequest ignored reviewers
         if: >-
           env.HAS_TOKEN == 'true' &&
@@ -2137,7 +2172,7 @@ jobs:
           (github.event.action == 'opened' || github.event.action == 'reopened')
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          IGNORED_REVIEWERS: ${{ inputs.ignored_reviewers }}
+          IGNORED_REVIEWERS: ${{ steps.reconcile.outputs.ignored-reviewers }}
           # Compatibility fallback for cross-repo callers that have not yet
           # granted pull-requests: write to their GITHUB_TOKEN.
           PAT_TOKEN: ${{ secrets.SLANG_PR_BOT_TOKEN }}

--- a/docs/maintainers/pr-review-board.md
+++ b/docs/maintainers/pr-review-board.md
@@ -39,7 +39,8 @@ sometimes a reviewer). Treat that as a starting point — change it if it's wron
 **How the Community/Bot shepherd is chosen:** linked-issue assignee who is
 source-internal for this repo (same criteria as Source Internal above), else
 whoever on the owners team (`pr-owners` / `bot-pr-owners`) has the strongest
-recent commit signal on the PR's files, else the maintainer fallback.
+recent commit signal on the PR's files, else the maintainer fallback (then the
+`default-reviewer` team).
 
 If the team rosters can't be read, Source and assignee stay blank and the
 nightly sweep retries. Internal membership is org-wide (with optional per-repo


### PR DESCRIPTION
## Motivation

PR board sync hardcoded a login as both `ignored_reviewers` (unrequest the auto-assigned reviewer who cannot approve) and `fallback_assignee` (last-resort owner). Changing that roster required a workflow edit.

The org team [`shader-slang/default-reviewer`](https://github.com/orgs/shader-slang/teams/default-reviewer) is now the source of truth for those logins.

## Proposed solution

Add `default_reviewer_team` (default `shader-slang/default-reviewer`). Reconcile lists it with `SLANG_PR_BOT_TOKEN`, unions members into the ignored-reviewer set, and uses the sorted-first member as last-resort assignee after `maintainer_team`.

`ignored_reviewers` and `fallback_assignee` remain optional extras with empty defaults. The onboarding unrequest step reads the ignored list from the reconcile step output so the team is listed once.

## Change summary

| File | Change |
| --- | --- |
| `.github/workflows/pr-board-sync.yml` | Team input; drop hardcoded login defaults |
| `.github/workflows/pr-board-sync.md` | Document the team |
| `docs/maintainers/pr-review-board.md` | Shepherd pick order includes the team |
| `.github/scripts/pr-assign.test.js` | Generic ignored-login fixture |

## Concepts and vocabulary

- **`default-reviewer` team** — org team whose members repo automation auto-requests; board sync unrequests them and may assign the first member when no maintainer/owner pick exists.
- **Ignored reviewers** — stripped on `opened`/`reopened` and when a new owner is assigned; not re-scanned on sweep for already-assigned PRs.

## Process report

The hardcoded login was workflow configuration, not assignment-algorithm logic. `selectAssigneeAndReviewers` already takes an `ignoredReviewers` set; this change only produces that set from `listTeamMembers`, the same pattern as `owners_team` / `maintainer_team`. An unreadable or empty team yields no ignored logins and no last-resort assignee (the sweep retries), matching other owner pools. No other workflow in this repo hardcoded that login.

Independent of #12982 (Sprint `iterationId` type).

**Test plan**

- [x] `node .github/scripts/pr-assign.test.js` / `pr-classify.test.js`
- [ ] After merge: confirm a new PR unrequests the team member if GitHub auto-requested them