### PR TITLE
Add search path list API and slangc -search-path-list

### DIFF
--- a/docs/command-line-slangc-reference.md
+++ b/docs/command-line-slangc-reference.md
@@ -122,6 +122,14 @@ Help formatting style
 Add a path to be used in resolving '#include' and 'import' operations. 
 
 
+<a id="search-path-list"></a>
+### -search-path-list
+
+**-search-path-list &lt;path&gt;**
+
+Add every search path listed in a text file. 
+
+
 <a id="lang"></a>
 ### -lang
 

--- a/include/slang.h
+++ b/include/slang.h
@@ -5902,6 +5902,30 @@ struct SlangGlobalSessionDesc
  */
 SLANG_EXTERN_C SLANG_API ISlangBlob* slang_createBlob(const void* data, size_t size);
 
+/** Read compiler search paths from a text file.
+ *
+ * The file contains one path per line. Empty lines are ignored and all other bytes are preserved,
+ * so paths may contain spaces. Both LF and CRLF line endings are accepted.
+ *
+ * @param path Path to the search path list.
+ * @param fileSystem File system used to read `path`, or null to use the operating-system file
+ *                   system.
+ * @param outSearchPaths (out) The loaded search paths.
+ * @param outSearchPathCount (out) The number of loaded search paths.
+ * @param outAllocation (out) Storage that owns the returned array and strings. Caller releases
+ *                            after `IGlobalSession::createSession` returns.
+ * @param outDiagnostics (out, optional) A diagnostic message when loading fails.
+ * @return `SLANG_OK` on success, `SLANG_E_INVALID_ARG` for null required arguments, or
+ *         `SLANG_FAIL` when the file cannot be read or contains an embedded null byte.
+ */
+SLANG_EXTERN_C SLANG_API SlangResult slang_readSearchPathsFile(
+    const char* path,
+    ISlangFileSystem* fileSystem,
+    const char* const** outSearchPaths,
+    SlangInt* outSearchPathCount,
+    ISlangUnknown** outAllocation,
+    ISlangBlob** outDiagnostics = nullptr);
+
 /* Serialize coverage metadata into the canonical
  * `.coverage-manifest.json` shape. Same bytes that `slangc` writes
  * alongside compiled output when `-trace-coverage` is on, available

--- a/source/slang/slang-api.cpp
+++ b/source/slang/slang-api.cpp
@@ -2,11 +2,13 @@
 
 #include "compiler-core/slang-artifact-associated-impl.h"
 #include "core/slang-builtin-module-cache.h"
+#include "core/slang-io.h"
 #include "core/slang-performance-profiler.h"
 #include "core/slang-platform.h"
 #include "core/slang-rtti-info.h"
 #include "core/slang-shared-library.h"
 #include "core/slang-signal.h"
+#include "core/slang-string-util.h"
 #include "slang-capability.h"
 #include "slang-compiler.h"
 #include "slang-internal.h"
@@ -1078,6 +1080,138 @@ SLANG_API void spSetDiagnosticFlags(slang::ICompileRequest* request, SlangDiagno
 }
 
 /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!! Blob Creation !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+
+namespace
+{
+
+class SearchPathListAllocation : public Slang::ComBaseObject, public ISlangUnknown
+{
+public:
+    SLANG_COM_BASE_IUNKNOWN_ALL
+
+    SlangResult load(const char* path, ISlangFileSystem* fileSystem, Slang::String& outError)
+    {
+        Slang::ScopedAllocation osContents;
+        Slang::ComPtr<ISlangBlob> fileSystemContents;
+        const void* contents = nullptr;
+        size_t contentsSize = 0;
+        SlangResult readResult;
+        if (fileSystem)
+        {
+            readResult = fileSystem->loadFile(path, fileSystemContents.writeRef());
+            if (SLANG_SUCCEEDED(readResult))
+            {
+                contents = fileSystemContents->getBufferPointer();
+                contentsSize = fileSystemContents->getBufferSize();
+            }
+        }
+        else
+        {
+            readResult = Slang::File::readAllBytes(path, osContents);
+            if (SLANG_SUCCEEDED(readResult))
+            {
+                contents = osContents.getData();
+                contentsSize = osContents.getSizeInBytes();
+            }
+        }
+        if (SLANG_FAILED(readResult))
+        {
+            outError = Slang::String("Cannot read search path list: ") + path;
+            return SLANG_FAIL;
+        }
+
+        SlangInt lineNumber = 0;
+        for (auto line : Slang::LineParser(
+                 Slang::UnownedStringSlice(static_cast<const char*>(contents), contentsSize)))
+        {
+            ++lineNumber;
+            if (!line.getLength())
+                continue;
+
+            for (const char* cursor = line.begin(); cursor != line.end(); ++cursor)
+            {
+                if (*cursor == 0)
+                {
+                    Slang::StringBuilder builder;
+                    builder << "Search path list contains a null byte on line " << lineNumber
+                            << ".";
+                    outError = builder.produceString();
+                    return SLANG_FAIL;
+                }
+            }
+            m_searchPaths.add(Slang::String(line));
+        }
+
+        for (const auto& searchPath : m_searchPaths)
+            m_searchPathPointers.add(searchPath.getBuffer());
+        return SLANG_OK;
+    }
+
+    char const* const* getSearchPaths() { return m_searchPathPointers.getBuffer(); }
+    SlangInt getSearchPathCount() { return m_searchPathPointers.getCount(); }
+
+private:
+    void* getInterface(const SlangUUID& uuid)
+    {
+        if (uuid == ISlangUnknown::getTypeGuid())
+            return static_cast<ISlangUnknown*>(this);
+        return nullptr;
+    }
+
+    Slang::List<Slang::String> m_searchPaths;
+    Slang::List<const char*> m_searchPathPointers;
+};
+
+static SlangResult _setSearchPathListDiagnostic(
+    SlangResult result,
+    const Slang::String& message,
+    ISlangBlob** outDiagnostics)
+{
+    if (outDiagnostics)
+        *outDiagnostics = Slang::StringBlob::create(message).detach();
+    return result;
+}
+
+} // namespace
+
+SLANG_EXTERN_C SLANG_API SlangResult slang_readSearchPathsFile(
+    const char* path,
+    ISlangFileSystem* fileSystem,
+    const char* const** outSearchPaths,
+    SlangInt* outSearchPathCount,
+    ISlangUnknown** outAllocation,
+    ISlangBlob** outDiagnostics)
+{
+    if (outDiagnostics)
+        *outDiagnostics = nullptr;
+    if (outSearchPaths)
+        *outSearchPaths = nullptr;
+    if (outSearchPathCount)
+        *outSearchPathCount = 0;
+    if (outAllocation)
+        *outAllocation = nullptr;
+    if (!outSearchPaths || !outSearchPathCount || !outAllocation)
+        return _setSearchPathListDiagnostic(
+            SLANG_E_INVALID_ARG,
+            "slang_readSearchPathsFile requires output pointers.",
+            outDiagnostics);
+    if (!path || !path[0])
+        return _setSearchPathListDiagnostic(
+            SLANG_E_INVALID_ARG,
+            "slang_readSearchPathsFile requires a file path.",
+            outDiagnostics);
+
+    Slang::ComPtr<SearchPathListAllocation> allocation(new SearchPathListAllocation);
+    Slang::String error;
+    SlangResult result = allocation->load(path, fileSystem, error);
+    if (SLANG_FAILED(result))
+        return _setSearchPathListDiagnostic(result, error, outDiagnostics);
+
+    *outSearchPaths = allocation->getSearchPaths();
+    *outSearchPathCount = allocation->getSearchPathCount();
+    *outAllocation = allocation.detach();
+    return SLANG_OK;
+}
 
 SLANG_EXTERN_C SLANG_API ISlangBlob* slang_createBlob(const void* data, size_t size)
 {

--- a/source/slang/slang-diagnostics.lua
+++ b/source/slang/slang-diagnostics.lua
@@ -268,6 +268,13 @@ err(
 )
 
 err(
+    "cannot-load-search-path-list",
+    117,
+    "cannot load search path list",
+    span { loc = "location", message = "~reason" }
+)
+
+err(
     "unknown-source-language",
     19,
     "unknown source language '~language'",

--- a/source/slang/slang-options.cpp
+++ b/source/slang/slang-options.cpp
@@ -111,6 +111,10 @@ static StdinSourceReadResult _readStdinSource(FILE* input, Index maxBytes, List<
 // All of the options are given an unique enum
 typedef CompilerOptionName OptionKind;
 
+// This option expands a file into `Include` entries while parsing the command line. It is not a
+// `CompilerOptionName` because a stored compiler option cannot own or report errors from the file.
+static constexpr OptionKind kSearchPathListOption = OptionKind::CountOf;
+
 struct Option
 {
     OptionKind optionKind;
@@ -493,6 +497,10 @@ void initCommandOptions(CommandOptions& options)
          "-I<path>, -I <path>",
          "Add a path to be used in resolving '#include' "
          "and 'import' operations."},
+        {kSearchPathListOption,
+         "-search-path-list",
+         "-search-path-list <path>",
+         "Add every search path listed in a text file."},
         {OptionKind::Language,
          "-lang",
          "-lang <language>",
@@ -3564,6 +3572,39 @@ SlangResult OptionsParser::_parse(int argc, char const* const* argv)
                 }
 
                 m_compileRequest->addSearchPath(String(slice).getBuffer());
+                break;
+            }
+        case kSearchPathListOption:
+            {
+                CommandLineArg fileName;
+                SLANG_RETURN_ON_FAIL(m_reader.expectArg(fileName));
+
+                const char* const* searchPaths = nullptr;
+                SlangInt searchPathCount = 0;
+                ComPtr<ISlangUnknown> allocation;
+                ComPtr<ISlangBlob> diagnostics;
+                SlangResult result = slang_readSearchPathsFile(
+                    fileName.value.getBuffer(),
+                    nullptr,
+                    &searchPaths,
+                    &searchPathCount,
+                    allocation.writeRef(),
+                    diagnostics.writeRef());
+                if (SLANG_FAILED(result))
+                {
+                    if (diagnostics)
+                    {
+                        m_sink->diagnose(Diagnostics::CannotLoadSearchPathList{
+                            .reason = String(UnownedStringSlice(
+                                static_cast<const char*>(diagnostics->getBufferPointer()),
+                                diagnostics->getBufferSize())),
+                            .location = fileName.loc});
+                    }
+                    return result;
+                }
+
+                for (SlangInt i = 0; i < searchPathCount; ++i)
+                    m_compileRequest->addSearchPath(searchPaths[i]);
                 break;
             }
         case OptionKind::TypeConformance:

--- a/tests/diagnostics/command-line/search-path-list.slang
+++ b/tests/diagnostics/command-line/search-path-list.slang
@@ -1,0 +1,6 @@
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK_MISSING_FILE):-search-path-list tests/diagnostics/command-line/missing-search-paths.txt
+//CHECK_MISSING_FILE: cannot load search path list
+//CHECK_MISSING_FILE: Cannot read search path list: tests/diagnostics/command-line/missing-search-paths.txt
+
+//DIAGNOSTIC_TEST:SIMPLE(diag=CHECK_MISSING_ARGUMENT):-search-path-list
+//CHECK_MISSING_ARGUMENT: expected an argument for command-line option '-search-path-list'

--- a/tests/language-feature/modules/search-path-list-option.slang
+++ b/tests/language-feature/modules/search-path-list-option.slang
@@ -1,0 +1,8 @@
+//TEST:SIMPLE: -search-path-list tests/language-feature/modules/search-path-list/search-paths.txt
+
+import search_path_list_dependency;
+
+int useSearchPathList()
+{
+    return searchPathListValue();
+}

--- a/tests/language-feature/modules/search-path-list/modules/search_path_list_dependency.slang
+++ b/tests/language-feature/modules/search-path-list/modules/search_path_list_dependency.slang
@@ -1,0 +1,6 @@
+module search_path_list_dependency;
+
+public int searchPathListValue()
+{
+    return 42;
+}

--- a/tests/language-feature/modules/search-path-list/search-paths.txt
+++ b/tests/language-feature/modules/search-path-list/search-paths.txt
@@ -1,0 +1,1 @@
+tests/language-feature/modules/search-path-list/modules

--- a/tools/slang-unit-test/unit-test-search-path-list.cpp
+++ b/tools/slang-unit-test/unit-test-search-path-list.cpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "core/slang-io.h"
+#include "core/slang-memory-file-system.h"
+#include "slang-com-ptr.h"
+#include "slang.h"
+#include "unit-test/slang-unit-test.h"
+
+using namespace Slang;
+
+namespace
+{
+
+struct TemporaryFile
+{
+    String path;
+
+    ~TemporaryFile()
+    {
+        if (path.getLength())
+            File::remove(path);
+    }
+};
+
+} // namespace
+
+SLANG_UNIT_TEST(SearchPathListABI)
+{
+    TemporaryFile file;
+    SLANG_CHECK_ABORT(SLANG_SUCCEEDED(
+        File::generateTemporary(UnownedStringSlice("slang-search-path-list"), file.path)));
+    SLANG_CHECK_ABORT(SLANG_SUCCEEDED(
+        File::writeAllText(file.path, "/project/src\r\n\r\n/sdk with spaces/math/src\n")));
+
+    const char* const* searchPaths = nullptr;
+    SlangInt searchPathCount = 0;
+    ComPtr<ISlangUnknown> allocation;
+    ComPtr<ISlangBlob> diagnostics;
+    SLANG_CHECK_ABORT(SLANG_SUCCEEDED(slang_readSearchPathsFile(
+        file.path.getBuffer(),
+        nullptr,
+        &searchPaths,
+        &searchPathCount,
+        allocation.writeRef(),
+        diagnostics.writeRef())));
+    SLANG_CHECK(!diagnostics);
+    SLANG_CHECK(searchPathCount == 2);
+    SLANG_CHECK(String(searchPaths[0]) == "/project/src");
+    SLANG_CHECK(String(searchPaths[1]) == "/sdk with spaces/math/src");
+
+    const char fileSystemContents[] = "relative/to/current-directory\n";
+    ComPtr<ISlangFileSystemExt> fileSystem(new MemoryFileSystem);
+    SLANG_CHECK_ABORT(SLANG_SUCCEEDED(
+        static_cast<MemoryFileSystem*>(fileSystem.get())
+            ->saveFile("search-paths.txt", fileSystemContents, sizeof(fileSystemContents) - 1)));
+    const char* const* fileSystemSearchPaths = nullptr;
+    SlangInt fileSystemSearchPathCount = 0;
+    ComPtr<ISlangUnknown> fileSystemAllocation;
+    SLANG_CHECK_ABORT(SLANG_SUCCEEDED(slang_readSearchPathsFile(
+        "search-paths.txt",
+        fileSystem,
+        &fileSystemSearchPaths,
+        &fileSystemSearchPathCount,
+        fileSystemAllocation.writeRef())));
+    SLANG_CHECK(fileSystemSearchPathCount == 1);
+    SLANG_CHECK(String(fileSystemSearchPaths[0]) == "relative/to/current-directory");
+
+    slang::SessionDesc sessionDesc;
+    sessionDesc.searchPaths = searchPaths;
+    sessionDesc.searchPathCount = searchPathCount;
+
+    ComPtr<slang::IGlobalSession> globalSession;
+    SLANG_CHECK_ABORT(
+        SLANG_SUCCEEDED(slang_createGlobalSession(SLANG_API_VERSION, globalSession.writeRef())));
+    ComPtr<slang::ISession> session;
+    SLANG_CHECK_ABORT(
+        SLANG_SUCCEEDED(globalSession->createSession(sessionDesc, session.writeRef())));
+
+    const char* const* searchPathsWithoutDiagnostics = nullptr;
+    SlangInt searchPathCountWithoutDiagnostics = 0;
+    ComPtr<ISlangUnknown> allocationWithoutDiagnostics;
+    SLANG_CHECK_ABORT(SLANG_SUCCEEDED(slang_readSearchPathsFile(
+        file.path.getBuffer(),
+        nullptr,
+        &searchPathsWithoutDiagnostics,
+        &searchPathCountWithoutDiagnostics,
+        allocationWithoutDiagnostics.writeRef())));
+
+    SLANG_CHECK_ABORT(SLANG_SUCCEEDED(File::writeAllText(file.path, "")));
+    const char* const* emptySearchPaths = nullptr;
+    SlangInt emptySearchPathCount = -1;
+    ComPtr<ISlangUnknown> emptyAllocation;
+    SLANG_CHECK_ABORT(SLANG_SUCCEEDED(slang_readSearchPathsFile(
+        file.path.getBuffer(),
+        nullptr,
+        &emptySearchPaths,
+        &emptySearchPathCount,
+        emptyAllocation.writeRef())));
+    SLANG_CHECK(emptySearchPathCount == 0);
+
+    sessionDesc.searchPaths = emptySearchPaths;
+    sessionDesc.searchPathCount = emptySearchPathCount;
+    SLANG_CHECK_ABORT(
+        SLANG_SUCCEEDED(globalSession->createSession(sessionDesc, session.writeRef())));
+
+    SLANG_CHECK(
+        slang_readSearchPathsFile(
+            nullptr,
+            nullptr,
+            &searchPaths,
+            &searchPathCount,
+            allocation.writeRef(),
+            diagnostics.writeRef()) == SLANG_E_INVALID_ARG);
+    SLANG_CHECK(
+        slang_readSearchPathsFile(
+            "",
+            nullptr,
+            &searchPaths,
+            &searchPathCount,
+            allocation.writeRef(),
+            diagnostics.writeRef()) == SLANG_E_INVALID_ARG);
+    SLANG_CHECK(
+        slang_readSearchPathsFile(
+            file.path.getBuffer(),
+            nullptr,
+            nullptr,
+            &searchPathCount,
+            allocation.writeRef(),
+            diagnostics.writeRef()) == SLANG_E_INVALID_ARG);
+
+    const char embeddedNull[] = "/first\n/sec\0ond\n";
+    SLANG_CHECK_ABORT(
+        SLANG_SUCCEEDED(File::writeAllBytes(file.path, embeddedNull, sizeof(embeddedNull) - 1)));
+    SLANG_CHECK(SLANG_FAILED(slang_readSearchPathsFile(
+        file.path.getBuffer(),
+        nullptr,
+        &searchPaths,
+        &searchPathCount,
+        allocation.writeRef(),
+        diagnostics.writeRef())));
+    SLANG_CHECK(
+        String(UnownedStringSlice(
+                   static_cast<const char*>(diagnostics->getBufferPointer()),
+                   diagnostics->getBufferSize()))
+            .indexOf("line 2") >= 0);
+
+    SLANG_CHECK(SLANG_FAILED(slang_readSearchPathsFile(
+        "/path/that/does/not/exist/search-paths.txt",
+        nullptr,
+        &searchPaths,
+        &searchPathCount,
+        allocation.writeRef(),
+        diagnostics.writeRef())));
+    SLANG_CHECK(!searchPaths);
+    SLANG_CHECK(searchPathCount == 0);
+    SLANG_CHECK(!allocation);
+    SLANG_CHECK(diagnostics);
+}


### PR DESCRIPTION
## Motivation

Hosts and `slangc` both need a way to load extra `-I` search paths from a text file without inventing a packaging-specific compiler ABI. Today the only public mechanism is to pass each path individually (`addSearchPath` / `-I`). Downstream tools that already write a file of include roots (package managers, build wrappers) have to reimplement the same parse-and-apply loop.

Consider a file `search-paths.txt`:

```
/abs/export-root-a
/abs/export-root-b
```

A session created with those two paths as extra search directories should resolve `import` / `#include` the same way as `slangc -I /abs/export-root-a -I /abs/export-root-b`.

## Proposed solution

Add a generic C API, `slang_readSearchPathsFile`, that reads one path per line (empty lines skipped, other bytes preserved, LF/CRLF, fail on unreadable file or embedded NUL). Paths are verbatim, same as `-I`: relative to process cwd, not the list file’s directory.

The returned `const char* const*` is owned by an `ISlangUnknown` allocation that the caller must keep alive at least until after `createSession` (or until they have copied the strings). `fileSystem` may be null to use the OS filesystem.

`slangc` grows a parse-time expander `-search-path-list <path>` that feeds the existing `addSearchPath` path. The token is a private `OptionKind::CountOf` sentinel, not a public `CompilerOptionName`, so structured `compilerOptionEntries` cannot silently no-op.

This is additive and independent of the packaging tool.

## Change summary

| Area | What it does |
| --- | --- |
| `include/slang.h` | Public `slang_readSearchPathsFile` free function |
| `source/slang/slang-api.cpp` | Parser + COM owner for the returned path array |
| `source/slang/slang-options.cpp` | `-search-path-list` CLI expander |
| `source/slang/slang-diagnostics.lua` | `cannot-load-search-path-list` (id 117) |
| `tools/slang-unit-test/unit-test-search-path-list.cpp` | ABI unit tests |
| `tests/language-feature/modules/search-path-list*` | End-to-end `import` via a list file |
| `tests/diagnostics/command-line/search-path-list.slang` | Missing-file CLI diagnostic |
| `docs/command-line-slangc-reference.md` | Generated `-help` markdown for the new option |

## Concepts and vocabulary

- **Search path list file**: a text file of extra module/`#include` search directories, one path per line. Same meaning as repeated `-I`.
- **Allocation blob (`outAllocation`)**: the COM object that owns the decoded string pointers. Callers must not free the `char*` array independently.
- **Parse-time expander**: CLI handling that turns `-search-path-list` into the existing search-path list before option application. It is not a stored `CompilerOptionName`.

## Process report

The original work landed on a packaging prototype branch. These two commits are the package-independent slice: the C API first, then the `slangc` option and tests.

`slang_readSearchPathsFile` is a new exported C function. It does not insert into a COM vtable. Auto-merge placed the declaration among the other free functions in `slang.h` (immediately before the later coverage-manifest serializer that already exists on `master`). Existing function signatures are unchanged.

The list format is intentionally dumb (verbatim lines) so hosts and `slangc` share one parser and so relative paths keep the same cwd-relative meaning as `-I`. Failing on embedded NUL avoids truncating a path at a hidden terminator.

`-search-path-list` is not a public compiler option enum value. A public `CompilerOptionName` with no `compilerOptionEntries` implementation would look supported in structured API use and then do nothing. Expanding at CLI parse time into `addSearchPath` is the same code path as `-I`.

Input shape: a UTF-8 (or otherwise byte-preserving) text file of paths. That is valid user input, not an accidental AST/IR spelling. The compiler already consumes search paths as opaque strings; this API only batches that existing input.

## Test plan

- [x] Cherry-picked onto `origin/master` as `add-search-path-list` (clean auto-merge)
- [ ] `slang-unit-test-tool/SearchPathListABI`
- [ ] `tests/language-feature/modules/search-path-list-option.slang`
- [ ] `tests/diagnostics/command-line/search-path-list.slang`
- [ ] Confirm `docs/command-line-slangc-reference.md` still matches `slangc -help-style markdown -h` after CI rebuild