### PR TITLE
Fix matrix layout specialization by giving the layout its own type

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -150,6 +150,51 @@ CI, which uploads its result as an artifact, and this workflow then posts the PR
 comment, because commenting needs a token the build job (possibly running a
 fork's code) must not hold.
 
+### Cherry-picking a SlangPy PR
+
+A Slang change that intentionally breaks SlangPy cannot be landed together with
+its SlangPy counterpart, which leaves a chicken-and-egg problem: the SlangPy fix
+does not compile until the Slang change has landed, and once it has landed,
+SlangPy `main` no longer compiles against Slang `master`. In between, **every**
+Slang PR fails `SlangPy Tests` through no fault of its own.
+
+To close that window, `ci-slangpy-trigger-test.yml` can name a SlangPy PR for
+SlangPy CI to merge into its `main` before building, so both halves of the change
+are tested together. We only send the number; SlangPy CI owns the checkout (see
+`ci-latest-slang.yml` in `shader-slang/slangpy`).
+
+Set it in `ci-slangpy-trigger-test.yml`:
+
+```yaml
+env:
+  SLANGPY_CHERRY_PICK_PR: "1135" # "" means no cherry-pick
+```
+
+**The setting only takes effect once it is on `master`.** `ci-slangpy-trigger-test.yml`
+runs on `pull_request_target`, which loads the workflow from the base branch — so
+a PR that edits this variable cannot exercise its own edit, and its `SlangPy Tests`
+check reports whatever `master` currently says. That check is therefore
+meaningless on such a PR: it is green when `master` has an empty value, and it
+fails during a breaking-change window regardless of what the PR does. Once the
+setting is on `master` it applies to every Slang PR at once, so keep the window
+short — land the SlangPy PR right after the Slang one, then set this back to `""`
+in a follow-up PR.
+
+**Getting a real result before merging.** Start a manual run, which reads the
+workflow from the branch you select rather than from `master`:
+
+1. Open the [`CI SlangPy Trigger Test` workflow](https://github.com/shader-slang/slang/actions/workflows/ci-slangpy-trigger-test.yml).
+2. Choose **Run workflow**, pick the branch carrying the `SLANGPY_CHERRY_PICK_PR`
+   value, and enter the Slang PR number to test.
+3. Post the resulting run's link as a comment on the PR, since this run is the
+   only evidence the combination works — the PR's own automatic check is not.
+
+The branch must exist in `shader-slang/slang`; the branch picker cannot see a
+fork's branches, so push a temporary branch here if the PR comes from a fork. The
+PR being _tested_ can live on a fork — it is fetched by number, not by branch
+name. SlangPy CI reports back to that PR's head commit, so a manual run updates
+the PR's `SlangPy Tests` status in place.
+
 ## 2. Reusable building blocks (`workflow_call`)
 
 No trigger of their own; see the first diagram for who calls them. The

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -153,47 +153,57 @@ fork's code) must not hold.
 ### Cherry-picking a SlangPy PR
 
 A Slang change that intentionally breaks SlangPy cannot be landed together with
-its SlangPy counterpart, which leaves a chicken-and-egg problem: the SlangPy fix
-does not compile until the Slang change has landed, and once it has landed,
-SlangPy `main` no longer compiles against Slang `master`. In between, **every**
-Slang PR fails `SlangPy Tests` through no fault of its own.
+its SlangPy counterpart, which leaves a chicken-and-egg problem: both fixes for
+the SlangPy and Slang must land together.
 
-To close that window, `ci-slangpy-trigger-test.yml` can name a SlangPy PR for
-SlangPy CI to merge into its `main` before building, so both halves of the change
-are tested together. We only send the number; SlangPy CI owns the checkout (see
-`ci-latest-slang.yml` in `shader-slang/slangpy`).
+To disconnect the cyclic dependency, `ci-slangpy-trigger-test.yml` can specify
+a SlangPy PR and it will be cherry-picked for SlangPy workflow just in Slang repo.
 
-Set it in `ci-slangpy-trigger-test.yml`:
+There are two workflow YML related to this process. Slang uses `ci-slangpy-trigger-test.yml`
+and it simply triggers the existing workflow on SlangPy repo, `ci-latest-slang.yml`.
+Note that their names are similar:
+- `ci-slangpy-trigger-test.yml` is in Slang repo
+- `ci-latest-slang.yml` is in SlangPy repo; not Slang repo.
+
+
+You can specify which PR to cherry-pick by setting the following in `ci-slangpy-trigger-test.yml`:
 
 ```yaml
 env:
   SLANGPY_CHERRY_PICK_PR: "1135" # "" means no cherry-pick
 ```
 
-**The setting only takes effect once it is on `master`.** `ci-slangpy-trigger-test.yml`
-runs on `pull_request_target`, which loads the workflow from the base branch — so
-a PR that edits this variable cannot exercise its own edit, and its `SlangPy Tests`
-check reports whatever `master` currently says. That check is therefore
-meaningless on such a PR: it is green when `master` has an empty value, and it
-fails during a breaking-change window regardless of what the PR does. Once the
-setting is on `master` it applies to every Slang PR at once, so keep the window
-short — land the SlangPy PR right after the Slang one, then set this back to `""`
-in a follow-up PR.
+For the security reason, this setting, unfortunately, is not effective unless it is
+merged to `master` branch. It means the CI runs showing up as a part of the PR page
+will ignore this setting.
 
-**Getting a real result before merging.** Start a manual run, which reads the
-workflow from the branch you select rather than from `master`:
+In order to workaround the limitation, you need to manually trigger the workflow
+with `branch` name and the PR number from "Action" page:
+- https://github.com/shader-slang/slang/actions/workflows/ci-slangpy-trigger-test.yml
 
-1. Open the [`CI SlangPy Trigger Test` workflow](https://github.com/shader-slang/slang/actions/workflows/ci-slangpy-trigger-test.yml).
-2. Choose **Run workflow**, pick the branch carrying the `SLANGPY_CHERRY_PICK_PR`
-   value, and enter the Slang PR number to test.
-3. Post the resulting run's link as a comment on the PR, since this run is the
-   only evidence the combination works — the PR's own automatic check is not.
+Click "Run workflow" button on the right side of the page. It will ask two info:
+- "Use workflow from" that takes a branch name
+- "Slang PR number to test against SlangPy"
 
-The branch must exist in `shader-slang/slang`; the branch picker cannot see a
-fork's branches, so push a temporary branch here if the PR comes from a fork. The
-PR being _tested_ can live on a fork — it is fetched by number, not by branch
-name. SlangPy CI reports back to that PR's head commit, so a manual run updates
-the PR's `SlangPy Tests` status in place.
+The `branch` should be the branch name the PR currently uses. And the branch must be
+a branch in the https://github.com/shader-slang/slang/; not a forked repo.
+
+Once the SlangPy workflow is triggered, you need to track the result from the SlangPy
+side:
+- https://github.com/shader-slang/slangpy/actions/workflows/ci-latest-slang.yml
+
+The manual run reports its result back to the PR, onto the same `SlangPy Tests`
+check that the automatic run wrote. A passing manual run therefore replaces the
+failure, and the PR page ends up green.
+
+That is convenient, but it means the check alone no longer tells you which run
+produced it: the same green mark appears whether the cherry-pick was applied or
+ignored. Please leave a comment on the PR linking the manual run, so a reviewer can
+tell the result came from a run that actually cherry-picked the SlangPy PR.
+
+Note that pushing a new commit re-runs the automatic workflow and turns the check
+back to a failure, so run the manual workflow after the last push.
+
 
 ## 2. Reusable building blocks (`workflow_call`)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -194,15 +194,11 @@ side:
 
 The manual run reports its result back to the PR, onto the same `SlangPy Tests`
 check that the automatic run wrote. A passing manual run therefore replaces the
-failure, and the PR page ends up green.
+failure, and the PR page will end up green.
 
-That is convenient, but it means the check alone no longer tells you which run
-produced it: the same green mark appears whether the cherry-pick was applied or
-ignored. Please leave a comment on the PR linking the manual run, so a reviewer can
-tell the result came from a run that actually cherry-picked the SlangPy PR.
-
-Note that pushing a new commit re-runs the automatic workflow and turns the check
-back to a failure, so run the manual workflow after the last push.
+It is worth noting that if you needed this feature of cherry-pick with the backward
+compatibility breaking change, you probably need to announce the breaking change to
+the community before merging the change.
 
 
 ## 2. Reusable building blocks (`workflow_call`)

--- a/.github/workflows/ci-slangpy-trigger-test.yml
+++ b/.github/workflows/ci-slangpy-trigger-test.yml
@@ -39,7 +39,11 @@ env:
   #
   # Setting this applies to every Slang PR, so keep the window short: land the SlangPy
   # PR right after the Slang one, then set this back to "".
-  SLANGPY_CHERRY_PICK_PR: ""
+  #
+  # Currently cherry-picking: shader-slang/slangpy#1135, needed by #12840, which
+  # retypes the layout parameter of `matrix` from `int` to the `MatrixLayoutMode`
+  # enum. REVERT THIS TO "" AS SOON AS slangpy#1135 HAS MERGED.
+  SLANGPY_CHERRY_PICK_PR: "1135"
 
 jobs:
   filter:

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2291,11 +2291,10 @@ struct vector : IRWArray<T>
     int getCount() { return N; }
 }
 
-//@public:
-/// The in-memory element order of a `matrix`.
-/// @remarks `Unknown` takes the order selected for the target. This is an enum rather than an
-/// `int` so an unresolved layout stays recognizable when passed as a generic argument.
-/// @category math_types Math types
+//@hidden:
+// The in-memory element order of a `matrix`. An enum rather than an `int` so that an
+// unresolved layout is still recognizable as a generic argument, where it sits beside
+// the row and column counts.
 enum MatrixLayoutMode : int
 {
     Unknown = $(SLANG_MATRIX_LAYOUT_MODE_UNKNOWN),

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2296,9 +2296,21 @@ static const int kRowMajorMatrixLayout = $(SLANG_MATRIX_LAYOUT_ROW_MAJOR);
 static const int kColumnMajorMatrixLayout = $(SLANG_MATRIX_LAYOUT_COLUMN_MAJOR);
 
 //@public:
+/// The in-memory element order of a `matrix`.
+/// @remarks `Unknown` takes the order selected for the target. This is an enum rather than an
+/// `int` so an unresolved layout stays recognizable when passed as a generic argument.
+/// @category math_types Math types
+enum MatrixLayoutMode : int
+{
+    Unknown = $(SLANG_MATRIX_LAYOUT_MODE_UNKNOWN),
+    RowMajor = $(SLANG_MATRIX_LAYOUT_ROW_MAJOR),
+    ColumnMajor = $(SLANG_MATRIX_LAYOUT_COLUMN_MAJOR),
+}
+
+//@public:
 /// A matrix with `R` rows and `C` columns, with elements of type `T`.
 /// @category math_types Math types
-__generic<T = float, let R : int = 4, let C : int = 4, let L : int = $(SLANG_MATRIX_LAYOUT_MODE_UNKNOWN)>
+__generic<T = float, let R : int = 4, let C : int = 4, let L : MatrixLayoutMode = MatrixLayoutMode.Unknown>
 __magic_type(MatrixExpressionType)
 struct matrix : IRWArray<vector<T,C>>
 {
@@ -2455,7 +2467,7 @@ extension vector<T,N> : IDifferentiable
     }
 }
 
-__generic<T:__BuiltinFloatingPointType, let N : int, let M : int, let L : int>
+__generic<T:__BuiltinFloatingPointType, let N : int, let M : int, let L : MatrixLayoutMode>
 extension matrix<T,N,M,L> : IFloat
 {
     // TODO(sai): not sure what's going on here? With the previous commit this was (this <= other)
@@ -2498,7 +2510,7 @@ extension matrix<T,N,M,L> : IFloat
 
 }
 
-__generic<T:IDifferentiable, let N : int, let M : int, let L : int>
+__generic<T:IDifferentiable, let N : int, let M : int, let L : MatrixLayoutMode>
 extension matrix<T,N,M,L> : IDifferentiable
 {
     // IDifferentiable.
@@ -2519,7 +2531,7 @@ extension matrix<T,N,M,L> : IDifferentiable
     }
 }
 
-__generic<let R : int, let C : int, let L : int>
+__generic<let R : int, let C : int, let L : MatrixLayoutMode>
 extension matrix<int16_t,R,C,L>
 {
     typealias T = int16_t;
@@ -2536,14 +2548,14 @@ vector<T,N*2> __makeVector(vector<T,N> vec1, vector<T,N> vec2);
 __generic<T>
 extension vector<T, 4>
 {
-    __generic<let L : int>
+    __generic<let L : MatrixLayoutMode>
     [__unsafeForceInlineEarly]
     __init(matrix<T, 2, 2, L> value)
     {
         this = __makeVector(value[0], value[1]);
     }
 }
-__generic<T, let L : int>
+__generic<T, let L : MatrixLayoutMode>
 extension matrix<T, 2, 2, L>
 {
     [__unsafeForceInlineEarly]
@@ -2832,7 +2844,7 @@ ${
 for( int R = 1; R <= 4; ++R )
 for( int C = 1; C <= 4; ++C )
 {
-    sb << "__generic<T, let L:int> __extension matrix<T, " << R << "," << C << ", L>\n{\n";
+    sb << "__generic<T, let L : MatrixLayoutMode> __extension matrix<T, " << R << "," << C << ", L>\n{\n";
 
     // initialize from R*C scalars
     if (R == 1 || C == 1)
@@ -2906,7 +2918,7 @@ __generic<ToType, let N : int> extension vector<ToType,N>
 }
 
 // If T is implicitly convertible to U, then matrix<T,R,C,L> is implicitly convertible to matrix<U,R,C,L>.
-__generic<ToType, let R : int, let C : int, let L : int> extension matrix<ToType,R,C,L>
+__generic<ToType, let R : int, let C : int, let L : MatrixLayoutMode> extension matrix<ToType,R,C,L>
 {
     __implicit_conversion(constraint)
     __intrinsic_op(BuiltinCast)
@@ -3051,7 +3063,7 @@ vector<T,N> operator$(op.name)(in out vector<T,N> value)
 {$(fixity.bodyPrefix) value = value $(op.binOp) __builtin_cast<T>(1); return $(fixity.returnVal); }
 
 $(fixity.qual)
-__generic<T : __BuiltinArithmeticType, let R : int, let C : int, let L : int>
+__generic<T : __BuiltinArithmeticType, let R : int, let C : int, let L : MatrixLayoutMode>
 [__unsafeForceInlineEarly]
 matrix<T,R,C> operator$(op.name)(in out matrix<T,R,C,L> value)
 {$(fixity.bodyPrefix) value = value $(op.binOp) __builtin_cast<T>(1); return $(fixity.returnVal); }
@@ -3242,7 +3254,7 @@ __generic<L: __BuiltinIntegerType, R: __BuiltinIntegerType, let N : int, let M :
 __intrinsic_op($(info.op))
 matrix<L,N,M> operator$(info.name)(matrix<L,N,M> left, matrix<R,N,M> right);
 
-__generic<L: __BuiltinIntegerType, R: __BuiltinIntegerType, let N : int, let M : int, let Layout : int>
+__generic<L: __BuiltinIntegerType, R: __BuiltinIntegerType, let N : int, let M : int, let Layout : MatrixLayoutMode>
 [__unsafeForceInlineEarly]
 matrix<L, N, M> operator$(info.name)=(in out matrix<L, N, M, Layout> left, matrix<R, N, M> right)
 {
@@ -3274,7 +3286,7 @@ __generic<L: __BuiltinIntegerType, R: __BuiltinIntegerType, let N : int, let M :
 __intrinsic_op($(info.op))
 matrix<L,N,M> operator$(info.name)(matrix<L,N,M> left, R right);
 
-__generic<L: __BuiltinIntegerType, R: __BuiltinIntegerType, let N : int, let M : int, let Layout : int>
+__generic<L: __BuiltinIntegerType, R: __BuiltinIntegerType, let N : int, let M : int, let Layout : MatrixLayoutMode>
 [__unsafeForceInlineEarly]
 matrix<L,N,M> operator$(info.name)=(in out matrix<L,N,M, Layout> left, R right)
 {
@@ -3329,7 +3341,7 @@ ${
         return left;
     }
 
-    __generic<T : $(op.interface), let R : int, let C : int, let Layout : int>
+    __generic<T : $(op.interface), let R : int, let C : int, let Layout : MatrixLayoutMode>
     [__unsafeForceInlineEarly]
     matrix<T,R,C> operator$(op.name)=(in out matrix<T,R,C,Layout> left, matrix<T,R,C> right)
     {
@@ -3337,7 +3349,7 @@ ${
         return left;
     }
 
-    __generic<T : $(op.interface), let R : int, let C : int, let Layout : int>
+    __generic<T : $(op.interface), let R : int, let C : int, let Layout : MatrixLayoutMode>
     [__unsafeForceInlineEarly]
     matrix<T,R,C> operator$(op.name)=(in out matrix<T,R,C, Layout> left, T right)
     {

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2303,14 +2303,6 @@ enum MatrixLayoutMode : int
     ColumnMajor = $(SLANG_MATRIX_LAYOUT_COLUMN_MAJOR),
 }
 
-//@hidden:
-// Declared after MatrixLayoutMode, and typed as it rather than as `int`, because their
-// only purpose is to be passed as the layout argument of `matrix<T, R, C, L>`, and that
-// parameter is a MatrixLayoutMode. Leaving them as `int` would make the constants
-// unusable in the one position they exist for.
-static const MatrixLayoutMode kRowMajorMatrixLayout = MatrixLayoutMode.RowMajor;
-static const MatrixLayoutMode kColumnMajorMatrixLayout = MatrixLayoutMode.ColumnMajor;
-
 //@public:
 /// A matrix with `R` rows and `C` columns, with elements of type `T`.
 /// @category math_types Math types

--- a/source/slang/core.meta.slang
+++ b/source/slang/core.meta.slang
@@ -2291,10 +2291,6 @@ struct vector : IRWArray<T>
     int getCount() { return N; }
 }
 
-//@hidden:
-static const int kRowMajorMatrixLayout = $(SLANG_MATRIX_LAYOUT_ROW_MAJOR);
-static const int kColumnMajorMatrixLayout = $(SLANG_MATRIX_LAYOUT_COLUMN_MAJOR);
-
 //@public:
 /// The in-memory element order of a `matrix`.
 /// @remarks `Unknown` takes the order selected for the target. This is an enum rather than an
@@ -2306,6 +2302,14 @@ enum MatrixLayoutMode : int
     RowMajor = $(SLANG_MATRIX_LAYOUT_ROW_MAJOR),
     ColumnMajor = $(SLANG_MATRIX_LAYOUT_COLUMN_MAJOR),
 }
+
+//@hidden:
+// Declared after MatrixLayoutMode, and typed as it rather than as `int`, because their
+// only purpose is to be passed as the layout argument of `matrix<T, R, C, L>`, and that
+// parameter is a MatrixLayoutMode. Leaving them as `int` would make the constants
+// unusable in the one position they exist for.
+static const MatrixLayoutMode kRowMajorMatrixLayout = MatrixLayoutMode.RowMajor;
+static const MatrixLayoutMode kColumnMajorMatrixLayout = MatrixLayoutMode.ColumnMajor;
 
 //@public:
 /// A matrix with `R` rows and `C` columns, with elements of type `T`.

--- a/source/slang/diff.meta.slang
+++ b/source/slang/diff.meta.slang
@@ -2662,7 +2662,7 @@ void __sincos_impl(vector<T, N> x, out vector<T, N> s, out vector<T, N> c)
     c = cos(x);
 }
 
-__generic<T : __BuiltinFloatingPointType, let N : int, let M : int, let L1 : int, let L2 : int>
+__generic<T : __BuiltinFloatingPointType, let N : int, let M : int, let L1 : MatrixLayoutMode, let L2 : MatrixLayoutMode>
 [Differentiable]
 [PrimalSubstituteOf(sincos)]
 [PreferRecompute]

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -11676,7 +11676,7 @@ void __wgsl_frexp(vector<T, N> x, out vector<T, N> fract, out vector<int, N> exp
     __intrinsic_asm "{ var s = frexp($0); ($1) = s.fract; ($2) = s.exp; }";
 }
 
-__generic<T : __BuiltinFloatingPointType, let N : int, let M : int, let L : int>
+__generic<T : __BuiltinFloatingPointType, let N : int, let M : int, let L : MatrixLayoutMode>
 [__readNone]
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, sm_4_0_version)]
@@ -13671,7 +13671,7 @@ void __wgsl_modf(vector<T,N> x, out vector<T,N> fract, out vector<T,N> whole)
     __intrinsic_asm "{ var s = modf($0); ($1) = s.fract; ($2) = s.whole; }";
 }
 
-__generic<T : __BuiltinFloatingPointType, let N : int, let M : int, let L : int>
+__generic<T : __BuiltinFloatingPointType, let N : int, let M : int, let L : MatrixLayoutMode>
 [__readNone]
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, sm_4_0_version)]
@@ -15141,7 +15141,7 @@ void sincos(vector<T,N> x, out vector<T,N> s, out vector<T,N> c)
     }
 }
 
-__generic<T : __BuiltinFloatingPointType, let N : int, let M : int, let L1: int, let L2 : int>
+__generic<T : __BuiltinFloatingPointType, let N : int, let M : int, let L1 : MatrixLayoutMode, let L2 : MatrixLayoutMode>
 [__readNone]
 [ForceInline]
 [require(cpp_cuda_glsl_hlsl_metal_spirv_wgsl_llvm, sm_4_0_version)]

--- a/source/slang/slang-check-decl.cpp
+++ b/source/slang/slang-check-decl.cpp
@@ -2546,7 +2546,7 @@ void SemanticsDeclHeaderVisitor::maybeApplyLayoutModifier(VarDeclBase* varDecl)
                 matrixType->getElementType(),
                 matrixType->getRowCount(),
                 matrixType->getColumnCount(),
-                getASTBuilder()->getIntVal(getASTBuilder()->getIntType(), matrixLayout));
+                getASTBuilder()->getIntVal(matrixType->getLayout()->getType(), matrixLayout));
             varDecl->type.type = newMatrixType;
         }
     }

--- a/source/slang/slang-check-expr.cpp
+++ b/source/slang/slang-check-expr.cpp
@@ -9333,7 +9333,7 @@ Expr* SemanticsExprVisitor::visitModifiedTypeExpr(ModifiedTypeExpr* expr)
                         matrixType->getRowCount(),
                         matrixType->getColumnCount(),
                         m_astBuilder->getIntVal(
-                            m_astBuilder->getIntType(),
+                            matrixType->getLayout()->getType(),
                             kMatrixLayoutMode_ColumnMajor));
                 }
                 else
@@ -9343,7 +9343,7 @@ Expr* SemanticsExprVisitor::visitModifiedTypeExpr(ModifiedTypeExpr* expr)
                         matrixType->getRowCount(),
                         matrixType->getColumnCount(),
                         m_astBuilder->getIntVal(
-                            m_astBuilder->getIntType(),
+                            matrixType->getLayout()->getType(),
                             kMatrixLayoutMode_RowMajor));
                 }
                 expr->type = m_astBuilder->getTypeType(baseType);

--- a/source/slang/slang-code-gen.h
+++ b/source/slang/slang-code-gen.h
@@ -89,6 +89,7 @@ struct RequiredLoweringPassSet
     bool lValueCast;
     bool sumVectorMatrix;
     bool lateRequireCapability;
+    bool unresolvedMatrixLayout;
 };
 
 /// A context for code generation in the compiler back-end

--- a/source/slang/slang-emit-spirv.cpp
+++ b/source/slang/slang-emit-spirv.cpp
@@ -10975,7 +10975,9 @@ struct SPIRVEmitContext : public SourceEmitterBase, public SPIRVEmitSharedContex
                     matrixType->getElementType(),
                     matrixType->getRowCount(),
                     matrixType->getColumnCount(),
-                    builder.getIntValue(builder.getIntType(), kMatrixLayoutMode_RowMajor));
+                    builder.getIntValue(
+                        matrixType->getLayout()->getFullType(),
+                        kMatrixLayoutMode_RowMajor));
             }
         }
         return type;

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -644,6 +644,16 @@ void calcRequiredLoweringPassSet(
     case kIROp_LateRequireCapability:
         result.lateRequireCapability = true;
         break;
+    case kIROp_MatrixType:
+        // A layout that is `Unknown` needs resolving. A non-literal layout is a generic
+        // parameter, which specialization may later fill with `Unknown`, so flag that too.
+        if (auto matrixType = as<IRMatrixType>(inst))
+        {
+            auto layout = as<IRIntLit>(matrixType->getLayout());
+            if (!layout || layout->getValue() == SLANG_MATRIX_LAYOUT_MODE_UNKNOWN)
+                result.unresolvedMatrixLayout = true;
+        }
+        break;
     }
     if (!result.generics || !result.existentialTypeLayout)
     {
@@ -1449,9 +1459,11 @@ Result linkAndOptimizeIR(
         SLANG_PASS(lowerLValueCast, targetProgram);
 
     // Fill in default matrix layout into matrix types that left layout unspecified. Must run
-    // before specialization, so `row_major float4x4` and `float4x4` match as one type, and
+    // before specialization, so `row_major float4x4` and `float4x4` match as one type (and so
+    // an `Unknown` generic argument is resolved before it is substituted into a clone), and
     // before `lowerEnumType`, which erases the `MatrixLayoutMode` type this pass looks for.
-    SLANG_PASS(specializeMatrixLayout, targetProgram);
+    if (requiredLoweringPassSet.unresolvedMatrixLayout)
+        SLANG_PASS(specializeMatrixLayout, targetProgram);
 
     // Lower enum types early since enums and enum casts may appear in
     // specialization & not resolving them here would block specialization.

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -645,8 +645,8 @@ void calcRequiredLoweringPassSet(
         result.lateRequireCapability = true;
         break;
     case kIROp_MatrixType:
-        // A layout that is `Unknown` needs resolving. A non-literal layout is a generic
-        // parameter, which specialization may later fill with `Unknown`, so flag that too.
+        // An `Unknown` layout needs the pass. So does `Unknown` passed as a generic argument,
+        // which this scan cannot recognize, so a generic (non-literal) layout requests it too.
         if (auto matrixType = as<IRMatrixType>(inst))
         {
             auto layout = as<IRIntLit>(matrixType->getLayout());
@@ -1458,10 +1458,9 @@ Result linkAndOptimizeIR(
     if (requiredLoweringPassSet.lValueCast)
         SLANG_PASS(lowerLValueCast, targetProgram);
 
-    // Fill in default matrix layout into matrix types that left layout unspecified. Must run
-    // before specialization, so `row_major float4x4` and `float4x4` match as one type (and so
-    // an `Unknown` generic argument is resolved before it is substituted into a clone), and
-    // before `lowerEnumType`, which erases the `MatrixLayoutMode` type this pass looks for.
+    // Fill in the default matrix layout where the source left it unspecified. Must run before
+    // specialization, so `row_major float4x4` and `float4x4` match as one type, and before
+    // `lowerEnumType`, which erases the `MatrixLayoutMode` type this pass looks for.
     if (requiredLoweringPassSet.unresolvedMatrixLayout)
         SLANG_PASS(specializeMatrixLayout, targetProgram);
 

--- a/source/slang/slang-emit.cpp
+++ b/source/slang/slang-emit.cpp
@@ -1448,6 +1448,11 @@ Result linkAndOptimizeIR(
     if (requiredLoweringPassSet.lValueCast)
         SLANG_PASS(lowerLValueCast, targetProgram);
 
+    // Fill in default matrix layout into matrix types that left layout unspecified. Must run
+    // before specialization, so `row_major float4x4` and `float4x4` match as one type, and
+    // before `lowerEnumType`, which erases the `MatrixLayoutMode` type this pass looks for.
+    SLANG_PASS(specializeMatrixLayout, targetProgram);
+
     // Lower enum types early since enums and enum casts may appear in
     // specialization & not resolving them here would block specialization.
     //
@@ -1473,9 +1478,6 @@ Result linkAndOptimizeIR(
         if (sink->getErrorCount() != 0)
             return SLANG_FAIL;
     }
-
-    // Fill in default matrix layout into matrix types that left layout unspecified.
-    SLANG_PASS(specializeMatrixLayout, targetProgram);
 
     // It's important that this takes place before defunctionalization as we
     // want to be able to easily discover the cooperate and fallback funcitons

--- a/source/slang/slang-ir-specialize-matrix-layout.cpp
+++ b/source/slang/slang-ir-specialize-matrix-layout.cpp
@@ -7,43 +7,107 @@
 namespace Slang
 {
 
-void visitParent(List<IRMatrixType*>& typeWorkList, IRInst* parent)
+// Returns true if `inst` is the `MatrixLayoutMode.Unknown` literal, i.e. a layout the source
+// left unspecified. `MatrixLayoutMode` is an enum rather than an `int` so that this stays
+// recognizable as a generic argument, where an `int` would look like a row or column count.
+static bool isUnknownMatrixLayout(IRInst* inst, IRType* matrixLayoutModeType)
 {
-    for (auto child : parent->getChildren())
+    auto lit = as<IRIntLit>(inst);
+    if (!lit || lit->getFullType() != matrixLayoutModeType)
+        return false;
+    return lit->getValue() == SLANG_MATRIX_LAYOUT_MODE_UNKNOWN;
+}
+
+// Collects the matrix types with an unspecified layout and the `specialize` insts that pass one
+// as a generic argument. The `MatrixLayoutMode` type is taken from the first matrix type seen.
+struct UnresolvedMatrixLayoutCollector
+{
+    IRType* matrixLayoutModeType = nullptr;
+    List<IRMatrixType*> matrixTypes;
+    List<IRSpecialize*> specializeInsts;
+
+    void visit(IRInst* parent)
     {
-        if (auto matrixType = as<IRMatrixType>(child))
+        for (auto child : parent->getChildren())
         {
-            if (auto constLayout = as<IRIntLit>(matrixType->getLayout()))
+            if (auto matrixType = as<IRMatrixType>(child))
             {
-                if (constLayout->getValue() == SLANG_MATRIX_LAYOUT_MODE_UNKNOWN)
+                // Any matrix type identifies `MatrixLayoutMode` for us.
+                if (!matrixLayoutModeType)
+                    matrixLayoutModeType = matrixType->getLayout()->getFullType();
+
+                if (isUnknownMatrixLayout(matrixType->getLayout(), matrixLayoutModeType))
+                    matrixTypes.add(matrixType);
+            }
+            visit(child);
+        }
+    }
+
+    void visitSpecializeInsts(IRInst* parent)
+    {
+        for (auto child : parent->getChildren())
+        {
+            if (auto specializeInst = as<IRSpecialize>(child))
+            {
+                for (UInt i = 0; i < specializeInst->getArgCount(); i++)
                 {
-                    typeWorkList.add(matrixType);
+                    if (isUnknownMatrixLayout(specializeInst->getArg(i), matrixLayoutModeType))
+                    {
+                        specializeInsts.add(specializeInst);
+                        break;
+                    }
                 }
             }
+            visitSpecializeInsts(child);
         }
-        visitParent(typeWorkList, child);
     }
-}
+};
 
 void specializeMatrixLayout(IRModule* module, TargetProgram* target)
 {
-    List<IRMatrixType*> typeWorkList;
-    visitParent(typeWorkList, module->getModuleInst());
+    UnresolvedMatrixLayoutCollector collector;
+    collector.visit(module->getModuleInst());
+    if (!collector.matrixLayoutModeType)
+        return;
+    collector.visitSpecializeInsts(module->getModuleInst());
 
     IRIntegerValue defaultLayout = target->getOptionSet().getMatrixLayoutMode();
     if (defaultLayout == SLANG_MATRIX_LAYOUT_MODE_UNKNOWN)
         defaultLayout = SLANG_MATRIX_LAYOUT_ROW_MAJOR;
 
     IRBuilder builder(module);
-    for (auto matrixType : typeWorkList)
+    auto resolvedLayout = builder.getIntValue(collector.matrixLayoutModeType, defaultLayout);
+
+    for (auto matrixType : collector.matrixTypes)
     {
         builder.setInsertBefore(matrixType);
         auto replacementMatrixType = builder.getMatrixType(
             matrixType->getElementType(),
             matrixType->getRowCount(),
             matrixType->getColumnCount(),
-            builder.getIntValue(builder.getIntType(), defaultLayout));
+            resolvedLayout);
         matrixType->replaceUsesWith(replacementMatrixType);
+    }
+
+    // Also resolve the layout where it is a generic argument, or specialization would substitute
+    // it into `matrix<T, N, M, L>` and mint a new unspecified-layout type after this pass ran.
+    for (auto specializeInst : collector.specializeInsts)
+    {
+        List<IRInst*> args;
+        for (UInt i = 0; i < specializeInst->getArgCount(); i++)
+        {
+            auto arg = specializeInst->getArg(i);
+            args.add(
+                isUnknownMatrixLayout(arg, collector.matrixLayoutModeType) ? resolvedLayout : arg);
+        }
+
+        builder.setInsertBefore(specializeInst);
+        auto replacement = builder.emitSpecializeInst(
+            specializeInst->getFullType(),
+            specializeInst->getBase(),
+            (UInt)args.getCount(),
+            args.getBuffer());
+        specializeInst->replaceUsesWith(replacement);
     }
 }
 

--- a/source/slang/slang-ir-specialize-matrix-layout.cpp
+++ b/source/slang/slang-ir-specialize-matrix-layout.cpp
@@ -7,10 +7,10 @@
 namespace Slang
 {
 
-// Returns true if `inst` is the `MatrixLayoutMode.Unknown` literal, i.e. a layout the source
-// left unspecified. `MatrixLayoutMode` is an enum rather than an `int` so that this stays
-// recognizable as a generic argument, where an `int` would look like a row or column count.
-// `inst` may be any operand (e.g. a `specialize` argument), so a non-layout is simply `false`.
+// Returns true if `inst` is the `MatrixLayoutMode.Unknown` literal, i.e. an unspecified layout.
+// `MatrixLayoutMode` is an enum rather than an `int` so the literal stays recognizable as a
+// generic argument. `inst` can be any `specialize` argument, so a non-match is not an error;
+// a matrix type's own layout operand is checked more strictly in `visitMatrixTypes`.
 static bool isUnknownMatrixLayout(IRInst* inst, IRType* matrixLayoutModeType)
 {
     auto lit = as<IRIntLit>(inst);
@@ -19,22 +19,23 @@ static bool isUnknownMatrixLayout(IRInst* inst, IRType* matrixLayoutModeType)
     return lit->getValue() == SLANG_MATRIX_LAYOUT_MODE_UNKNOWN;
 }
 
-// Collects the matrix types with an unspecified layout and the `specialize` insts that pass one
-// as a generic argument. The `MatrixLayoutMode` type is taken from the first matrix type seen.
+// Collects the matrix types with an unspecified layout, and the `specialize` insts that pass
+// one as a generic argument.
 struct UnresolvedMatrixLayoutCollector
 {
     IRType* matrixLayoutModeType = nullptr;
     List<IRMatrixType*> matrixTypes;
     List<IRSpecialize*> specializeInsts;
 
+    // Collects the matrix types whose layout is `Unknown`. Every layout operand is typed
+    // `MatrixLayoutMode`, and IR types are deduplicated, so the first matrix type seen provides
+    // that type and every later one must agree; a mismatch would be silently skipped.
     void visitMatrixTypes(IRInst* parent)
     {
         for (auto child : parent->getChildren())
         {
             if (auto matrixType = as<IRMatrixType>(child))
             {
-                // Any matrix type identifies `MatrixLayoutMode` for us. Types are deduplicated,
-                // so every layout operand must share it; a mismatch would be silently skipped.
                 auto layout = matrixType->getLayout();
                 if (!matrixLayoutModeType)
                     matrixLayoutModeType = layout->getFullType();
@@ -47,7 +48,8 @@ struct UnresolvedMatrixLayoutCollector
         }
     }
 
-    // Requires `matrixLayoutModeType`, i.e. call after `visitMatrixTypes`.
+    // Collects the `specialize` insts that pass `Unknown` as a generic argument.
+    // Needs `matrixLayoutModeType`, so call after `visitMatrixTypes`.
     void visitSpecializeInsts(IRInst* parent)
     {
         for (auto child : parent->getChildren())

--- a/source/slang/slang-ir-specialize-matrix-layout.cpp
+++ b/source/slang/slang-ir-specialize-matrix-layout.cpp
@@ -10,6 +10,7 @@ namespace Slang
 // Returns true if `inst` is the `MatrixLayoutMode.Unknown` literal, i.e. a layout the source
 // left unspecified. `MatrixLayoutMode` is an enum rather than an `int` so that this stays
 // recognizable as a generic argument, where an `int` would look like a row or column count.
+// `inst` may be any operand (e.g. a `specialize` argument), so a non-layout is simply `false`.
 static bool isUnknownMatrixLayout(IRInst* inst, IRType* matrixLayoutModeType)
 {
     auto lit = as<IRIntLit>(inst);
@@ -26,23 +27,27 @@ struct UnresolvedMatrixLayoutCollector
     List<IRMatrixType*> matrixTypes;
     List<IRSpecialize*> specializeInsts;
 
-    void visit(IRInst* parent)
+    void visitMatrixTypes(IRInst* parent)
     {
         for (auto child : parent->getChildren())
         {
             if (auto matrixType = as<IRMatrixType>(child))
             {
-                // Any matrix type identifies `MatrixLayoutMode` for us.
+                // Any matrix type identifies `MatrixLayoutMode` for us. Types are deduplicated,
+                // so every layout operand must share it; a mismatch would be silently skipped.
+                auto layout = matrixType->getLayout();
                 if (!matrixLayoutModeType)
-                    matrixLayoutModeType = matrixType->getLayout()->getFullType();
+                    matrixLayoutModeType = layout->getFullType();
+                SLANG_ASSERT(layout->getFullType() == matrixLayoutModeType);
 
-                if (isUnknownMatrixLayout(matrixType->getLayout(), matrixLayoutModeType))
+                if (isUnknownMatrixLayout(layout, matrixLayoutModeType))
                     matrixTypes.add(matrixType);
             }
-            visit(child);
+            visitMatrixTypes(child);
         }
     }
 
+    // Requires `matrixLayoutModeType`, i.e. call after `visitMatrixTypes`.
     void visitSpecializeInsts(IRInst* parent)
     {
         for (auto child : parent->getChildren())
@@ -66,7 +71,7 @@ struct UnresolvedMatrixLayoutCollector
 void specializeMatrixLayout(IRModule* module, TargetProgram* target)
 {
     UnresolvedMatrixLayoutCollector collector;
-    collector.visit(module->getModuleInst());
+    collector.visitMatrixTypes(module->getModuleInst());
     if (!collector.matrixLayoutModeType)
         return;
     collector.visitSpecializeInsts(module->getModuleInst());

--- a/source/slang/slang-ir-specialize-matrix-layout.cpp
+++ b/source/slang/slang-ir-specialize-matrix-layout.cpp
@@ -28,22 +28,27 @@ void specializeMatrixLayout(IRModule* module, TargetProgram* target)
     if (!matrixLayoutModeType)
         return;
 
-    IRBuilder builder(module);
-
-    // `MatrixLayoutMode.Unknown` is a single deduplicated constant, so every unspecified layout
-    // in the module, including one passed as a generic argument, is a use of this instruction.
-    auto unknownLayout =
-        builder.getIntValue(matrixLayoutModeType, SLANG_MATRIX_LAYOUT_MODE_UNKNOWN);
-    if (!unknownLayout->hasUses())
-        return;
-
     IRIntegerValue defaultLayout = target->getOptionSet().getMatrixLayoutMode();
     if (defaultLayout == SLANG_MATRIX_LAYOUT_MODE_UNKNOWN)
         defaultLayout = SLANG_MATRIX_LAYOUT_ROW_MAJOR;
 
-    // Users are hoistable, so `replaceUsesWith` re-deduplicates them: a matrix type with the
-    // resolved layout merges with an existing identical one instead of becoming a duplicate.
-    unknownLayout->replaceUsesWith(builder.getIntValue(matrixLayoutModeType, defaultLayout));
+    IRBuilder builder(module);
+    auto unknownLayout =
+        builder.getIntValue(matrixLayoutModeType, SLANG_MATRIX_LAYOUT_MODE_UNKNOWN);
+    auto resolvedLayout = builder.getIntValue(matrixLayoutModeType, defaultLayout);
+
+    // `Unknown` is one deduplicated constant, so every unspecified layout is a use of it: a matrix
+    // type's layout operand, or a `specialize` argument headed into one. Other uses are enum values
+    // the user wrote (e.g. a `switch` case label) and must keep their value. `replaceOperand`
+    // re-deduplicates the user, so no duplicate matrix types are left behind.
+    for (auto use = unknownLayout->firstUse; use;)
+    {
+        auto nextUse = use->nextUse; // `replaceOperand` unlinks `use`.
+        auto user = use->getUser();
+        if (as<IRMatrixType>(user) || as<IRSpecialize>(user))
+            builder.replaceOperand(use, resolvedLayout);
+        use = nextUse;
+    }
 }
 
 } // namespace Slang

--- a/source/slang/slang-ir-specialize-matrix-layout.cpp
+++ b/source/slang/slang-ir-specialize-matrix-layout.cpp
@@ -7,115 +7,43 @@
 namespace Slang
 {
 
-// Returns true if `inst` is the `MatrixLayoutMode.Unknown` literal, i.e. an unspecified layout.
-// `MatrixLayoutMode` is an enum rather than an `int` so the literal stays recognizable as a
-// generic argument. `inst` can be any `specialize` argument, so a non-match is not an error;
-// a matrix type's own layout operand is checked more strictly in `visitMatrixTypes`.
-static bool isUnknownMatrixLayout(IRInst* inst, IRType* matrixLayoutModeType)
+// Returns the `MatrixLayoutMode` enum type, or null if `parent` contains no matrix type.
+// Every matrix type carries this type on its layout operand, so any of them reveals it.
+// Recurses because matrix types inside generics are not hoisted to global scope.
+static IRType* findMatrixLayoutModeType(IRInst* parent)
 {
-    auto lit = as<IRIntLit>(inst);
-    if (!lit || lit->getFullType() != matrixLayoutModeType)
-        return false;
-    return lit->getValue() == SLANG_MATRIX_LAYOUT_MODE_UNKNOWN;
+    for (auto child : parent->getChildren())
+    {
+        if (auto matrixType = as<IRMatrixType>(child))
+            return matrixType->getLayout()->getFullType();
+        if (auto layoutModeType = findMatrixLayoutModeType(child))
+            return layoutModeType;
+    }
+    return nullptr;
 }
-
-// Collects the matrix types with an unspecified layout, and the `specialize` insts that pass
-// one as a generic argument.
-struct UnresolvedMatrixLayoutCollector
-{
-    IRType* matrixLayoutModeType = nullptr;
-    List<IRMatrixType*> matrixTypes;
-    List<IRSpecialize*> specializeInsts;
-
-    // Collects the matrix types whose layout is `Unknown`. Every layout operand is typed
-    // `MatrixLayoutMode`, and IR types are deduplicated, so the first matrix type seen provides
-    // that type and every later one must agree; a mismatch would be silently skipped.
-    void visitMatrixTypes(IRInst* parent)
-    {
-        for (auto child : parent->getChildren())
-        {
-            if (auto matrixType = as<IRMatrixType>(child))
-            {
-                auto layout = matrixType->getLayout();
-                if (!matrixLayoutModeType)
-                    matrixLayoutModeType = layout->getFullType();
-                SLANG_ASSERT(layout->getFullType() == matrixLayoutModeType);
-
-                if (isUnknownMatrixLayout(layout, matrixLayoutModeType))
-                    matrixTypes.add(matrixType);
-            }
-            visitMatrixTypes(child);
-        }
-    }
-
-    // Collects the `specialize` insts that pass `Unknown` as a generic argument.
-    // Needs `matrixLayoutModeType`, so call after `visitMatrixTypes`.
-    void visitSpecializeInsts(IRInst* parent)
-    {
-        for (auto child : parent->getChildren())
-        {
-            if (auto specializeInst = as<IRSpecialize>(child))
-            {
-                for (UInt i = 0; i < specializeInst->getArgCount(); i++)
-                {
-                    if (isUnknownMatrixLayout(specializeInst->getArg(i), matrixLayoutModeType))
-                    {
-                        specializeInsts.add(specializeInst);
-                        break;
-                    }
-                }
-            }
-            visitSpecializeInsts(child);
-        }
-    }
-};
 
 void specializeMatrixLayout(IRModule* module, TargetProgram* target)
 {
-    UnresolvedMatrixLayoutCollector collector;
-    collector.visitMatrixTypes(module->getModuleInst());
-    if (!collector.matrixLayoutModeType)
+    auto matrixLayoutModeType = findMatrixLayoutModeType(module->getModuleInst());
+    if (!matrixLayoutModeType)
         return;
-    collector.visitSpecializeInsts(module->getModuleInst());
+
+    IRBuilder builder(module);
+
+    // `MatrixLayoutMode.Unknown` is a single deduplicated constant, so every unspecified layout
+    // in the module, including one passed as a generic argument, is a use of this instruction.
+    auto unknownLayout =
+        builder.getIntValue(matrixLayoutModeType, SLANG_MATRIX_LAYOUT_MODE_UNKNOWN);
+    if (!unknownLayout->hasUses())
+        return;
 
     IRIntegerValue defaultLayout = target->getOptionSet().getMatrixLayoutMode();
     if (defaultLayout == SLANG_MATRIX_LAYOUT_MODE_UNKNOWN)
         defaultLayout = SLANG_MATRIX_LAYOUT_ROW_MAJOR;
 
-    IRBuilder builder(module);
-    auto resolvedLayout = builder.getIntValue(collector.matrixLayoutModeType, defaultLayout);
-
-    for (auto matrixType : collector.matrixTypes)
-    {
-        builder.setInsertBefore(matrixType);
-        auto replacementMatrixType = builder.getMatrixType(
-            matrixType->getElementType(),
-            matrixType->getRowCount(),
-            matrixType->getColumnCount(),
-            resolvedLayout);
-        matrixType->replaceUsesWith(replacementMatrixType);
-    }
-
-    // Also resolve the layout where it is a generic argument, or specialization would substitute
-    // it into `matrix<T, N, M, L>` and mint a new unspecified-layout type after this pass ran.
-    for (auto specializeInst : collector.specializeInsts)
-    {
-        List<IRInst*> args;
-        for (UInt i = 0; i < specializeInst->getArgCount(); i++)
-        {
-            auto arg = specializeInst->getArg(i);
-            args.add(
-                isUnknownMatrixLayout(arg, collector.matrixLayoutModeType) ? resolvedLayout : arg);
-        }
-
-        builder.setInsertBefore(specializeInst);
-        auto replacement = builder.emitSpecializeInst(
-            specializeInst->getFullType(),
-            specializeInst->getBase(),
-            (UInt)args.getCount(),
-            args.getBuffer());
-        specializeInst->replaceUsesWith(replacement);
-    }
+    // Users are hoistable, so `replaceUsesWith` re-deduplicates them: a matrix type with the
+    // resolved layout merges with an existing identical one instead of becoming a duplicate.
+    unknownLayout->replaceUsesWith(builder.getIntValue(matrixLayoutModeType, defaultLayout));
 }
 
 } // namespace Slang

--- a/source/standard-modules/numerics/__builtin-differentiable.slang
+++ b/source/standard-modules/numerics/__builtin-differentiable.slang
@@ -41,7 +41,7 @@ public matrix<TDestination, R, C, L> __differentiableNumericsConstructMatrixFrom
     TSource : __BuiltinFloatingPointType,
     let R : int,
     let C : int,
-    let L : int>(TSource value)
+    let L : MatrixLayoutMode>(TSource value)
 {
     return matrix<TDestination, R, C, L>(__realCast<TDestination>(value));
 }

--- a/source/standard-modules/numerics/__builtin.slang
+++ b/source/standard-modules/numerics/__builtin.slang
@@ -57,7 +57,7 @@ public bool __numericsBuiltinAll<let N : int>(vector<bool, N> value)
 
 [__readNone]
 [__unsafeForceInlineEarly]
-public bool __numericsBuiltinAny<let R : int, let C : int, let L : int>(
+public bool __numericsBuiltinAny<let R : int, let C : int, let L : MatrixLayoutMode>(
     matrix<bool, R, C, L> value)
 {
     [ForceUnroll]
@@ -75,7 +75,7 @@ public bool __numericsBuiltinAny<let R : int, let C : int, let L : int>(
 
 [__readNone]
 [__unsafeForceInlineEarly]
-public bool __numericsBuiltinAll<let R : int, let C : int, let L : int>(
+public bool __numericsBuiltinAll<let R : int, let C : int, let L : MatrixLayoutMode>(
     matrix<bool, R, C, L> value)
 {
     [ForceUnroll]

--- a/source/standard-modules/numerics/builtin-conformances.slang
+++ b/source/standard-modules/numerics/builtin-conformances.slang
@@ -242,7 +242,7 @@ public extension<let N : int> vector<bool, N> : IBooleanMask
     [__unsafeForceInlineEarly] bool all() { return __numericsBuiltinAll(this); }
 }
 
-public extension<let R : int, let C : int, let L : int>
+public extension<let R : int, let C : int, let L : MatrixLayoutMode>
     matrix<bool, R, C, L> : IBooleanMask
 {
     [__unsafeForceInlineEarly]
@@ -436,7 +436,7 @@ public extension<
     T : __BuiltinFloatingPointType & IScalarFractional,
     let R : int,
     let C : int,
-    let L : int>
+    let L : MatrixLayoutMode>
     matrix<T, R, C, L> : IComponentwiseOrdered
 {
     typealias Scalar = T;
@@ -500,7 +500,7 @@ public extension<
     T : __BuiltinFloatingPointType & IScalarFractional,
     let R : int,
     let C : int,
-    let L : int>
+    let L : MatrixLayoutMode>
     matrix<T, R, C, L> : IFractional
 {
     [__unsafeForceInlineEarly]

--- a/source/standard-modules/numerics/differentiable-conformances.slang
+++ b/source/standard-modules/numerics/differentiable-conformances.slang
@@ -361,7 +361,7 @@ public extension<
     T : __BuiltinFloatingPointType & IScalarDifferentiableFloatingPoint,
     let R : int,
     let C : int,
-    let L : int>
+    let L : MatrixLayoutMode>
     matrix<T, R, C, L> : IDifferentiableFloatingPoint
 {
     [Differentiable] [ForceInline]
@@ -385,7 +385,7 @@ public extension<
     T : __BuiltinFloatingPointType & IDifferentiableExponentialFunctions,
     let R : int,
     let C : int,
-    let L : int>
+    let L : MatrixLayoutMode>
     matrix<T, R, C, L> : IDifferentiableExponentialFunctions
 {
     SLANG_NUMERICS_DIFFERENTIABLE_MATRIX_EXPONENTIAL_REQUIREMENTS
@@ -395,7 +395,7 @@ public extension<
     T : __BuiltinFloatingPointType & IDifferentiableTrigonometricFunctions,
     let R : int,
     let C : int,
-    let L : int>
+    let L : MatrixLayoutMode>
     matrix<T, R, C, L> : IDifferentiableTrigonometricFunctions
 {
     SLANG_NUMERICS_DIFFERENTIABLE_MATRIX_TRIGONOMETRIC_REQUIREMENTS
@@ -405,7 +405,7 @@ public extension<
     T : __BuiltinFloatingPointType & IDifferentiableInverseTrigonometricFunctions,
     let R : int,
     let C : int,
-    let L : int>
+    let L : MatrixLayoutMode>
     matrix<T, R, C, L> : IDifferentiableInverseTrigonometricFunctions
 {
     SLANG_NUMERICS_DIFFERENTIABLE_MATRIX_INVERSE_REQUIREMENTS
@@ -415,7 +415,7 @@ public extension<
     T : __BuiltinFloatingPointType & IDifferentiableHyperbolicFunctions,
     let R : int,
     let C : int,
-    let L : int>
+    let L : MatrixLayoutMode>
     matrix<T, R, C, L> : IDifferentiableHyperbolicFunctions
 {
     SLANG_NUMERICS_DIFFERENTIABLE_MATRIX_HYPERBOLIC_REQUIREMENTS
@@ -425,7 +425,7 @@ public extension<
     T : __BuiltinFloatingPointType & IDifferentiableRootFunctions,
     let R : int,
     let C : int,
-    let L : int>
+    let L : MatrixLayoutMode>
     matrix<T, R, C, L> : IDifferentiableRootFunctions
 {
     SLANG_NUMERICS_DIFFERENTIABLE_MATRIX_ROOT_REQUIREMENTS
@@ -435,7 +435,7 @@ public extension<
     T : __BuiltinFloatingPointType & IScalarDifferentiableReal,
     let R : int,
     let C : int,
-    let L : int>
+    let L : MatrixLayoutMode>
     matrix<T, R, C, L> : IDifferentiableRealOrderingFunctions
 {
     SLANG_NUMERICS_DIFFERENTIABLE_MATRIX_ORDERING_REQUIREMENTS

--- a/source/standard-modules/numerics/floating-point-conformances.slang
+++ b/source/standard-modules/numerics/floating-point-conformances.slang
@@ -1059,7 +1059,7 @@ public extension<
     T : __BuiltinFloatingPointType & IScalarFloatingPoint,
     let R : int,
     let C : int,
-    let L : int> matrix<T, R, C, L> : IFloatingPoint
+    let L : MatrixLayoutMode> matrix<T, R, C, L> : IFloatingPoint
 {
     [__unsafeForceInlineEarly]
     This floor()
@@ -1240,7 +1240,7 @@ public extension<
     T : __BuiltinFloatingPointType & ITrigonometricFunctions,
     let R : int,
     let C : int,
-    let L : int> matrix<T, R, C, L> : ITrigonometricFunctions
+    let L : MatrixLayoutMode> matrix<T, R, C, L> : ITrigonometricFunctions
 {
     [__unsafeForceInlineEarly]
     This sin()
@@ -1311,7 +1311,7 @@ public extension<
     T : __BuiltinFloatingPointType & IExponentialFunctions,
     let R : int,
     let C : int,
-    let L : int> matrix<T, R, C, L> : IExponentialFunctions
+    let L : MatrixLayoutMode> matrix<T, R, C, L> : IExponentialFunctions
 {
     [__unsafeForceInlineEarly]
     This exponential()
@@ -1421,7 +1421,7 @@ public extension<
     T : __BuiltinFloatingPointType & IInverseTrigonometricFunctions,
     let R : int,
     let C : int,
-    let L : int> matrix<T, R, C, L> : IInverseTrigonometricFunctions
+    let L : MatrixLayoutMode> matrix<T, R, C, L> : IInverseTrigonometricFunctions
 {
     [__unsafeForceInlineEarly]
     This asin()
@@ -1489,7 +1489,7 @@ public extension<
     T : __BuiltinFloatingPointType & IHyperbolicFunctions,
     let R : int,
     let C : int,
-    let L : int> matrix<T, R, C, L> : IHyperbolicFunctions
+    let L : MatrixLayoutMode> matrix<T, R, C, L> : IHyperbolicFunctions
 {
     [__unsafeForceInlineEarly]
     This sinh()
@@ -1581,7 +1581,7 @@ public extension<
     T : __BuiltinFloatingPointType & IRootFunctions,
     let R : int,
     let C : int,
-    let L : int> matrix<T, R, C, L> : IRootFunctions
+    let L : MatrixLayoutMode> matrix<T, R, C, L> : IRootFunctions
 {
     [__unsafeForceInlineEarly]
     This squareRoot()
@@ -1618,7 +1618,7 @@ public extension<
     T : __BuiltinFloatingPointType & IScalarReal,
     let R : int,
     let C : int,
-    let L : int> matrix<T, R, C, L> : IRealOrderingFunctions
+    let L : MatrixLayoutMode> matrix<T, R, C, L> : IRealOrderingFunctions
 {
     [__unsafeForceInlineEarly]
     This minimum(This other)

--- a/tests/numerics/interfaces-builtins.slang
+++ b/tests/numerics/interfaces-builtins.slang
@@ -375,31 +375,31 @@ void main()
     float2x2 legacyFloatMatrix = legacyBuiltinFloatMatrix(float2x2(1.0));
     int2 legacyIntegerVector = legacyBuiltinIntegerVector(int2(1));
 
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorLeft = 1.0;
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorRight = 2.0;
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorMinimum =
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorLeft = 1.0;
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorRight = 2.0;
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorMinimum =
         realMinimum(rowMajorLeft, rowMajorRight);
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorClamped =
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorClamped =
         realClamp(rowMajorRight, rowMajorLeft, rowMajorRight);
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorSmoothed =
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorSmoothed =
         realSmoothstep(rowMajorLeft, rowMajorRight, rowMajorRight);
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorStep =
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorStep =
         realStep(rowMajorRight, rowMajorLeft);
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorNegative = -1.0;
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorAbsolute =
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorNegative = -1.0;
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorAbsolute =
         absoluteValue(rowMajorNegative);
-    matrix<bool, 2, 2, kRowMajorMatrixLayout> rowMajorFinite =
+    matrix<bool, 2, 2, MatrixLayoutMode.RowMajor> rowMajorFinite =
         floatingPointIsFinite(rowMajorLeft);
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorRounding =
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorRounding =
         floatingPointRounding(rowMajorLeft);
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorFractionalParts =
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorFractionalParts =
         floatingPointFractionalParts(rowMajorLeft);
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorBinaryRepresentation =
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorBinaryRepresentation =
         floatingPointBinaryRepresentationOperations(rowMajorLeft, rowMajorRight);
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorIntegralPart;
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorSplitFractional =
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorIntegralPart;
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorSplitFractional =
         floatingPointSplit(rowMajorLeft, rowMajorIntegralPart);
-    matrix<float, 2, 2, kRowMajorMatrixLayout> rowMajorElementary =
+    matrix<float, 2, 2, MatrixLayoutMode.RowMajor> rowMajorElementary =
         elementaryCurve(rowMajorLeft);
 
     outputBuffer[0] =

--- a/tests/spirv/matrix-layout-dedup-specialization.slang
+++ b/tests/spirv/matrix-layout-dedup-specialization.slang
@@ -1,0 +1,25 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute -matrix-layout-row-major
+
+// With -matrix-layout-row-major, `row_major float4x4` and `float4x4` are the same type, so `Foo`
+// must be specialized only once. That requires matrix layouts to be resolved before
+// specialization; otherwise the two spellings key as different generic arguments.
+
+struct Foo<T>
+{
+    T v;
+}
+
+StructuredBuffer<Foo<row_major float4x4> > a;
+StructuredBuffer<Foo<float4x4> > b;
+RWStructuredBuffer<float> outBuf;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    outBuf[0] = a[0].v[0][0] + b[0].v[0][0];
+}
+
+// A second `Foo` would be emitted under the same name, suffixed _0 by the disassembler.
+// The positive check anchors the negative one so a rename cannot make it vacuous.
+// CHECK: %Foo_std430 = OpTypeStruct
+// CHECK-NOT: %Foo_std430_0 = OpTypeStruct

--- a/tests/spirv/matrix-layout-enum-value-use.slang
+++ b/tests/spirv/matrix-layout-enum-value-use.slang
@@ -1,0 +1,33 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv-asm -entry main -stage compute
+
+// `MatrixLayoutMode` is a public enum, so `MatrixLayoutMode.Unknown` is also an ordinary value.
+// A `switch` case label on it is lowered while its type is still the enum, which makes it the
+// same deduplicated constant as the unspecified layout operand of `float4x4`. Resolving that
+// layout to the target default must leave the case label at 0; it used to become the default
+// layout's value, so the `Unknown` case silently matched the wrong enumerator.
+
+StructuredBuffer<float4x4> a;
+RWStructuredBuffer<int> outBuf;
+uniform int selector;
+
+int classify(MatrixLayoutMode m)
+{
+    switch (m)
+    {
+    case MatrixLayoutMode.Unknown:
+        return 100;
+    case MatrixLayoutMode.RowMajor:
+        return 200;
+    default:
+        return 300;
+    }
+}
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    outBuf[0] = classify(MatrixLayoutMode(selector)) + int(a[0][0][0]);
+}
+
+// The case labels must be the enumerators as written, in source order.
+// CHECK: OpSwitch %{{[A-Za-z0-9_]+}} %{{[0-9]+}} 0 %{{[0-9]+}} 1 %{{[0-9]+}}

--- a/tests/spirv/matrix-layout-late-specialize-module.slang
+++ b/tests/spirv/matrix-layout-late-specialize-module.slang
@@ -1,0 +1,59 @@
+// Non-test helper module for matrix-layout-late-specialize.slang (no //TEST: directive).
+// Cloned into the linked module only when Thing<float> is specialized from the conformance,
+// so its matrix<T, R, C> mentions keep the defaulted (unknown) layout until then.
+module "matrix-layout-late-specialize-module";
+
+public interface IAcc
+{
+    static void acc(This* buf, int idx, This v);
+}
+
+public extension<T : __BuiltinFloatingPointType, let R : int, let C : int> matrix<T, R, C> : IAcc
+{
+    public static void acc(matrix<T, R, C>* buf, int idx, matrix<T, R, C> v)
+    {
+        T* p = (T*)(buf + idx);
+        [ForceUnroll]
+        for (int r = 0; r < R; ++r)
+            [ForceUnroll]
+            for (int c = 0; c < C; ++c)
+                p[r * C + c] = v[r][c];
+    }
+}
+
+public struct DTensor<T : IDifferentiable & IAcc>
+    where T.Differential : IAcc
+{
+    public T* primal;
+    public T.Differential* grad;
+
+    [BackwardDerivative(get_bwd)]
+    public T get(int i)
+    {
+        return primal[i];
+    }
+
+    public void get_bwd(int i, T.Differential v)
+    {
+        T.Differential::acc(grad, i, v);
+    }
+}
+
+[anyValueSize(32)]
+public dyn interface IThing
+{
+    [Differentiable]
+    float eval(no_diff int i, float4 v);
+}
+
+public struct Thing<Real : __BuiltinFloatingPointType> : IThing
+{
+    DTensor<matrix<Real, 4, 4> > t;
+
+    [Differentiable]
+    public float eval(no_diff int i, float4 v)
+    {
+        vector<Real, 4> vr = { Real(v.x), Real(v.y), Real(v.z), Real(v.w) };
+        return __realCast<float, Real>(mul(vr, t.get(i)).x);
+    }
+}

--- a/tests/spirv/matrix-layout-late-specialize.slang
+++ b/tests/spirv/matrix-layout-late-specialize.slang
@@ -1,0 +1,31 @@
+//TEST:SIMPLE(filecheck=CHECK): -target spirv -entry main -stage compute -matrix-layout-row-major -conformance "Thing<float>:IThing=0"
+
+// Generic bodies from an imported module are cloned lazily when the conformance's specialized
+// type is instantiated - after specializeMatrixLayout. The unknown-layout matrix minted there
+// used to lower to a second, identically named _MatrixStorage struct (the disassembler
+// suffixes it _0), and an OpPtrAccessChain mixing the two fails spirv-val.
+
+import "matrix-layout-late-specialize-module";
+
+uniform StructuredBuffer<IThing> things;
+RWStructuredBuffer<float> outBuf;
+
+[Differentiable]
+float f(IThing t, no_diff int i, float4 v)
+{
+    return t.eval(i, v);
+}
+
+[numthreads(1, 1, 1)]
+void main(uint3 tid: SV_DispatchThreadID)
+{
+    var dv = diffPair(float4(1), float4(0));
+    __bwd_diff(f)(things[0], int(tid.x), dv, 1.0f);
+    outBuf[0] = dv.d.x;
+}
+
+// The positive check anchors the negative one so a storage-struct rename cannot make it
+// vacuous. `natural` is the buffer layout rule, orthogonal to -matrix-layout-row-major.
+// CHECK: OpEntryPoint
+// CHECK: %_MatrixStorage_float4x4natural = OpTypeStruct
+// CHECK-NOT: _MatrixStorage_float4x4natural_0


### PR DESCRIPTION
## Motivation

When a shader writes `float4x4` without saying `row_major` or `column_major`, the
layout stays unresolved until a later pass fills in the target's default. If that
unresolved layout is handed to a generic first, specialization bakes it in and builds
a matrix type the pass has already run past, so it never gets fixed.

The sentinel for "unresolved" was a plain `int`, so once it was passed as a generic
argument nothing told it apart from the row and column counts beside it:

```
specialize(matrixIDifferentiableWitness, Real, 4 : Int, 4 : Int, 0 : Int, witness)
```

`specializeMatrixLayout` could therefore only resolve layouts written on a matrix
type, where operand position identifies them. Specialization then substituted the
sentinel into the generic's `matrix<T, N, M, L>` and minted a fresh
unspecified-layout matrix type after the pass had already run.

The result is two versions of what should be one type reaching code generation: same
name, different layout. Mixing them produces an `OpPtrAccessChain` that fails
spirv-val.

## Proposed solution

Give the layout its own type. `MatrixLayoutMode` is declared in the core module and
used for the layout parameter of `matrix`, so the sentinel carries its type wherever
it travels. One run of the pass, before specialization, then resolves it both on
matrix types and in generic arguments, and nothing downstream can reintroduce it.

The pass also has to run before `lowerEnumType`, which erases `MatrixLayoutMode` back
to `int`; after that point the check would degenerate to "any `int` equal to 0" and
would rewrite unrelated generic arguments.

## Change summary

| Area | Change |
| --- | --- |
| `core.meta.slang`, `diff.meta.slang`, `hlsl.meta.slang` | Declare `MatrixLayoutMode` and use it for the layout parameter of `matrix`. |
| `source/standard-modules/numerics/**` | Retype the same parameter in the numerics modules (5 files, 20 declarations). |
| `slang-ir-specialize-matrix-layout.cpp` | Resolve the layout in generic arguments as well as on matrix types. |
| `slang-emit.cpp`, `slang-code-gen.h` | Run the pass before specialization and before `lowerEnumType`. |
| `slang-check-decl.cpp`, `slang-check-expr.cpp`, `slang-emit-spirv.cpp` | Follow-on adjustments for the new parameter type. |
| `tests/spirv/**`, `tests/numerics/**` | Regression tests for the deduplication, the late-specialization path, and enum-value use. |
| `.github/workflows/**` | Temporary SlangPy CI cherry-pick; see the last section. |

## Breaking change

### 1. Generic parameters that carry a matrix layout

Any declaration that takes the layout as a generic parameter must retype that
parameter from `int` to `MatrixLayoutMode`. This is the common case: SlangPy hit it in
two places, and Slang's own numerics modules in twenty.

The diagnostic looks like this:

```
error[E30019]: type mismatch in expression
  --> your-shader.slang:1:69
  |
1 | extension<T, let R : int, let C : int, let L : int> matrix<T, R, C, L> {}
  |                                                                     ^ expected an expression of type 'MatrixLayoutMode', got 'int'
```

To fix it, change only that parameter's type. The row and column counts stay `int`:

```diff
-extension<T, let R : int, let C : int, let L : int> matrix<T, R, C, L> { ... }
+extension<T, let R : int, let C : int, let L : MatrixLayoutMode> matrix<T, R, C, L> { ... }
```

```diff
-__generic<T : IPrintable, let R : int, let C : int, let L : int>
+__generic<T : IPrintable, let R : int, let C : int, let L : MatrixLayoutMode>
 extension matrix<T, R, C, L> : IPrintable { ... }
```

### 2. `kRowMajorMatrixLayout` and `kColumnMajorMatrixLayout` are removed

```diff
-matrix<float, 4, 4, kRowMajorMatrixLayout> m;
+matrix<float, 4, 4, MatrixLayoutMode.RowMajor> m;
```

They predate the enum, were declared under `//@hidden:`, and are now redundant with the
enumerators. `MatrixLayoutMode` itself is `//@hidden:` as well, but usable by name.

### What is not affected

- Ordinary matrix declarations: `float4x4`, `matrix<float, 4, 4>`, `row_major float4x4`.
- A constant layout argument. Both `matrix<float, 4, 4, MatrixLayoutMode.RowMajor>` and
  `matrix<float, 4, 4, MatrixLayoutMode(1)>` compile.
- Using a layout where an integer is wanted, since an enum converts to its tag type
  implicitly.

### Why case 1 cannot be made backward compatible

A generic parameter is not a value, so there is nothing to convert at the use site: by
the time `L` reaches `matrix<T, R, C, L>` it is a parameter of type `int`, not the
integer `1`. Bridging it would need a `Val` meaning "cast a non-constant `int` to an
enum", which would give one layout two representations that compare unequal — the exact
ambiguity this PR removes. Constant arguments have no such problem, which is why case 3
above still works.

## Concepts and vocabulary

- **Unresolved layout** — the sentinel a matrix type carries when the source did not
  say `row_major` or `column_major`; a later target-specific pass replaces it with the
  target default.
- **`specializeMatrixLayout`** — the IR pass that performs that replacement.
- **`lowerEnumType`** — the pass that erases enums back to their tag type. It bounds
  how late `specializeMatrixLayout` may run, since afterwards a `MatrixLayoutMode` is
  indistinguishable from any other `int`.

## Process report

**Why a distinct type rather than a distinguished integer.** The pass needs to
recognise an unresolved layout in a position where operand order carries no meaning —
a generic argument list, where the layout sits beside two `int` dimensions. A
sentinel value cannot be recognised there without guessing at positions; a distinct
type can. That is also why the fix belongs in the representation rather than in
`specializeMatrixLayout`: making the consumer smarter would leave the ambiguity in
place for every other consumer.

**Why the numerics modules changed.** `source/standard-modules/numerics/**` declared
the same parameter as `let L : int` and passes it to `matrix<T, R, C, L>`. These are
compiled by `slang-bootstrap` during the build, so leaving them failed the build on
every platform rather than only affecting downstream code. Only declarations that
feed the fourth argument of `matrix<>` were changed; `let L : int` parameters that
carry a dimension, as in `vector<U, L>` and `matrix<T, C, L>` elsewhere in the tree,
keep their `int` type.

**Why the layout constants were removed rather than retyped.** They were introduced
before `MatrixLayoutMode` existed, when an `int` constant was the only way to name a
layout. Retyping them would have left two spellings of one value with the enum as the
obvious canonical one, and the set was arbitrarily incomplete anyway, since `Unknown`
never had a matching constant.

## Temporary: SlangPy CI cherry-pick

This change breaks SlangPy, which declares the same parameter as `int`, and the two
repositories cannot be updated in one commit. `SLANGPY_CHERRY_PICK_PR` in
`ci-slangpy-trigger-test.yml` is therefore set to shader-slang/slangpy#1135 so SlangPy
CI merges that PR before building, and both halves are tested together. The mechanism
itself landed separately in #12975.

**Set `SLANGPY_CHERRY_PICK_PR` back to `""` once shader-slang/slangpy#1135 has
merged.** `.github/workflows/README.md` documents the mechanism and how to verify it,
since the automatic check on a PR cannot exercise its own setting.

