### PR TITLE
tests/spvdb/lib: Clean up warnings

### DIFF
--- a/tests/spvdb/lib/core/value.h
+++ b/tests/spvdb/lib/core/value.h
@@ -38,20 +38,20 @@ struct Value
     } scalar = {};
 
     // Non-empty when kind == Composite.
-    std::vector<Value> elements;
+    std::vector<Value> elements = {};
     // Parallel to elements; non-empty only for struct composites where member
     // names are known (e.g. values built from DebugTypeComposite/SpvOpTypeStruct).
     // Empty for vectors, matrices, and arrays.
-    std::vector<std::string> member_names;
+    std::vector<std::string> member_names = {};
 
     // Non-empty when kind == Pointer.
     // Logical pointer: (storage_class, base_variable_result_id, access_chain).
     uint32_t ptr_storage_class = 0;
     uint32_t ptr_base_var = 0;
-    std::vector<uint32_t> ptr_chain;
+    std::vector<uint32_t> ptr_chain = {};
 
     // Human-readable type name; populated by inspection functions.
-    std::string type_name;
+    std::string type_name = {};
 
     // --- Factories ---
     static Value make_bool(bool v)

--- a/tests/spvdb/lib/interpreter/glsl_std_450.cpp
+++ b/tests/spvdb/lib/interpreter/glsl_std_450.cpp
@@ -147,12 +147,6 @@ static float f16_to_f32(uint16_t h)
 
 // ---- helpers ---------------------------------------------------------------
 
-static bool is64(const Value &v)
-{
-    return v.kind == Value::Kind::Float64 || v.kind == Value::Kind::Int64
-        || v.kind == Value::Kind::UInt64;
-}
-
 // Apply a unary float function element-wise.
 static Value fmap1(const Value &a, float (*f32)(float), double (*f64)(double))
 {
@@ -220,8 +214,6 @@ Value dispatch_glsl_std_450(uint32_t inst_id,
                             const std::vector<Value> &args,
                             std::vector<std::string> &diagnostics)
 {
-    auto &a0 = args.size() > 0 ? args[0]
-                               : (const Value &) (*(const Value *) nullptr); // will guard below
     auto get = [&](size_t i) -> const Value &
     {
         static Value undef = Value::make_u32(0);


### PR DESCRIPTION
Add default values to spvdb::Value members that didn't have them. This removes warnings about missing field initializers when constructing a Value using designated initializers for only some of the member fields.

Remove a trivial unused helper function is64().

Remove an unused declaration in dispatch_glsl_std_450(). That declaration was UB anyways, since it formed a reference to nullptr.