### PR TITLE
Mark stale agentic tests as expected failures

### DIFF
--- a/docs/generated/tests/_meta/expected-failures.txt
+++ b/docs/generated/tests/_meta/expected-failures.txt
@@ -198,3 +198,22 @@ docs/generated/tests/design/pipeline/04c-layout-ir/raytracing-callable-payload-r
 # the diagnostic sorts the list, which would make the text order-stable by
 # construction rather than a reflection of the merge order.
 docs/generated/tests/design/pipeline/05-ir-passes/typeflow-report-dynamic-dispatch-sites.slang
+
+# Surfaced on nightly run 34561421312:
+# https://github.com/shader-slang/slang/actions/runs/34561421312
+# Generated expectations awaiting bundle regeneration. PR #12986 changed
+# the matrix-layout operand's dumped IR type from `Int` to `Enum(Int)`,
+# and PR #12884 added the `base_instance` parameter to Metal vertex
+# entry-point signatures. The compiler output is intentional; these
+# failures are stale generated test content.
+docs/generated/tests/coverage/legalize/metal-vertex-compute-sysvals.slang
+docs/generated/tests/design/ir-reference/types/mat1x1-minimum-shape.slang
+docs/generated/tests/design/ir-reference/types/mat-shape-operands.slang
+docs/generated/tests/design/ir-reference/types/mat-rectangular-2x3.slang
+docs/generated/tests/design/pipeline/04-ast-to-ir/cbuffer-mixed-types-lowers-to-struct-with-mixed-fields.slang
+docs/generated/tests/design/pipeline/04-ast-to-ir/lower-double-matrix.slang
+docs/generated/tests/design/pipeline/04-ast-to-ir/lower-half-matrix.slang
+docs/generated/tests/design/pipeline/04-ast-to-ir/lower-mat-double-rectangular.slang
+docs/generated/tests/design/pipeline/04-ast-to-ir/lower-mat-half-rectangular.slang
+docs/generated/tests/design/pipeline/04-ast-to-ir/lower-mat2x4-rectangular.slang
+docs/generated/tests/design/pipeline/04-ast-to-ir/lower-mat4x2-rectangular.slang


### PR DESCRIPTION
## Motivation

The [agentic nightly run](https://github.com/shader-slang/slang/actions/runs/34561421312)
began failing 11 generated tests after two intentional compiler-output changes. Until the affected
bundles are regenerated, these stale expectations should not fail the nightly gate.

## Proposed solution

Add the 11 exact `slang-test` reporter keys to the agentic suite's expected-failure baseline, with
the failing run and causes documented. Entries that begin passing will still be reported so they
can be removed after bundle regeneration.

## Change summary

- Mark one stale Metal output expectation as an expected failure.
- Mark ten stale matrix IR-dump expectations as expected failures.
- Leave the generated test files unchanged pending bundle regeneration.

## Concepts and vocabulary

- **Agentic expected-failure baseline:** The suite-local list that reclassifies documented failures
  while continuing to report entries that unexpectedly pass.
- **Reporter key:** The exact test name that `slang-test` matches against an expected-failure entry.

## Process report

PR #12986 changed the matrix-layout operand's dumped IR type from `Int` to `Enum(Int)`, making ten
generated checks stale. PR #12884 added the `base_instance` parameter to Metal vertex entry-point
signatures, making one generated check stale. Both compiler outputs are intentional, so the
generated bundles—not the compiler producers—need regeneration.

At the exact failing revision, `c7954ebd1f1984ad2bfde15f76248db41dc34aa3`, the unchanged baseline
reproduced one pass and 11 failures. With this expected-failure list, the same `test-server` run
exits successfully with one ordinary pass and 11 expected failures. Targeted agentic lint reports
zero errors and one pre-existing warning in `coverage/legalize`.
