### PR TITLE
Remove cherry-pick for SlangPy test

### DIFF
--- a/.github/workflows/ci-slangpy-trigger-test.yml
+++ b/.github/workflows/ci-slangpy-trigger-test.yml
@@ -39,11 +39,7 @@ env:
   #
   # Setting this applies to every Slang PR, so keep the window short: land the SlangPy
   # PR right after the Slang one, then set this back to "".
-  #
-  # Currently cherry-picking: shader-slang/slangpy#1135, needed by #12840, which
-  # retypes the layout parameter of `matrix` from `int` to the `MatrixLayoutMode`
-  # enum. REVERT THIS TO "" AS SOON AS slangpy#1135 HAS MERGED.
-  SLANGPY_CHERRY_PICK_PR: "1135"
+  SLANGPY_CHERRY_PICK_PR: ""
 
 jobs:
   filter:


### PR DESCRIPTION
The PR no longer needs to be cherry-picked because it is merged:
- https://github.com/shader-slang/slangpy/pull/1135