### PR TITLE
Stop heap-allocating per alias query in redundancy removal (Metal 1.4x)

### DIFF
--- a/source/slang/slang-ir-util.cpp
+++ b/source/slang/slang-ir-util.cpp
@@ -1,5 +1,6 @@
 #include "slang-ir-util.h"
 
+#include "core/slang-short-list.h"
 #include "slang-ir-clone.h"
 #include "slang-ir-dce.h"
 #include "slang-ir-dominators.h"
@@ -952,7 +953,16 @@ IRInst* getRootAddr(IRInst* addr)
     return addr;
 }
 
-IRInst* getRootAddr(IRInst* addr, List<IRInst*>& outAccessChain, List<IRInst*>* outTypes)
+// Walk `addr` to its root, appending each access-chain key LEAF-FIRST. Shared by
+// the public `getRootAddr` (which reverses afterwards, so callers see root-first)
+// and by `canAddressesPotentiallyAlias`, which indexes from the end instead so it
+// can keep its chains on the stack. Templated on the list type for exactly that
+// reason -- one walker means the two cannot drift apart.
+template<typename TChainList, typename TTypeList>
+static IRInst* _collectAccessChainLeafFirst(
+    IRInst* addr,
+    TChainList& outAccessChain,
+    TTypeList* outTypes)
 {
     for (;;)
     {
@@ -971,10 +981,16 @@ IRInst* getRootAddr(IRInst* addr, List<IRInst*>& outAccessChain, List<IRInst*>* 
         }
         break;
     }
+    return addr;
+}
+
+IRInst* getRootAddr(IRInst* addr, List<IRInst*>& outAccessChain, List<IRInst*>* outTypes)
+{
+    auto root = _collectAccessChainLeafFirst(addr, outAccessChain, outTypes);
     outAccessChain.reverse();
     if (outTypes)
         outTypes->reverse();
-    return addr;
+    return root;
 }
 
 
@@ -1181,8 +1197,17 @@ bool canAddressesPotentiallyAlias(
     // then they cannot alias.
     if (root1 == root2)
     {
-        List<IRInst*> accessChain1;
-        List<IRInst*> accessChain2;
+        // Stack-allocated, and collected leaf-first so no reverse is needed: the
+        // loop below indexes from the end instead. This branch is the hot one
+        // whenever a target flattens shader parameters into one aggregate
+        // (Metal, and the CPU-like targets), because then every address in the
+        // function shares a root and lands here -- at which point two heap
+        // allocations per query, once per (address, instruction) scan step, are
+        // most of what the surrounding pass does. 8 covers every access chain
+        // that occurs in practice; deeper ones still work, they just spill to the
+        // heap as before.
+        ShortList<IRInst*, 8> accessChain1;
+        ShortList<IRInst*, 8> accessChain2;
 
         // Since getRootBufferOrAddr has a different behavior around
         // RWStructuredBufferGetElementPtr compared to getRootAddr,
@@ -1190,14 +1215,24 @@ bool canAddressesPotentiallyAlias(
         // that we can handle here, so that we don't need to handle the nuance
         // of whether or not to trace past any RWStructuredBufferGetElementPtr.
         //
-        root1 = getRootAddr(addr1, accessChain1, nullptr);
-        root2 = getRootAddr(addr2, accessChain2, nullptr);
+        root1 = _collectAccessChainLeafFirst<ShortList<IRInst*, 8>, List<IRInst*>>(
+            addr1,
+            accessChain1,
+            nullptr);
+        root2 = _collectAccessChainLeafFirst<ShortList<IRInst*, 8>, List<IRInst*>>(
+            addr2,
+            accessChain2,
+            nullptr);
         if (root1 != root2)
             return true;
-        for (Index i = 0; i < Math::Min(accessChain1.getCount(), accessChain2.getCount()); i++)
+        const Index count1 = accessChain1.getCount();
+        const Index count2 = accessChain2.getCount();
+        for (Index i = 0; i < Math::Min(count1, count2); i++)
         {
-            auto node1 = accessChain1[i];
-            auto node2 = accessChain2[i];
+            // Indices run root-first, as they did when both chains were reversed
+            // into root-first `List`s; these are leaf-first, so walk from the end.
+            auto node1 = accessChain1[count1 - 1 - i];
+            auto node2 = accessChain2[count2 - 1 - i];
             if (as<IRStructKey>(node1) && as<IRStructKey>(node2))
             {
                 // Two different field keys means the two addresses cannot alias.
@@ -1658,13 +1693,22 @@ bool isSideEffectFreeFunctionalCall(
 template<typename TFunc>
 void forEachAssociatedCallee(IRInst* callee, TFunc callback)
 {
-    traverseUsers<IRAnnotation>(
-        callee,
-        [&](IRAnnotation* annotation)
-        {
-            if (annotation->getTarget() == callee)
-                callback(annotation->getInst());
-        });
+    // Walked directly rather than through `traverseUsers`, which snapshots the
+    // whole use list into a `List` before iterating. That snapshot exists so a
+    // callback can mutate the IR; this one only reads decorations off the
+    // annotation's target, so it buys nothing here and costs a heap allocation
+    // plus a full copy per query -- and on a hot intrinsic the use list has one
+    // entry per call site. Callers that memoize this query pay that once per
+    // callee; the uncached callers that remain (slang-ir-simplify-for-emit.cpp,
+    // the autodiff passes) pay it per query.
+    for (auto use = callee->firstUse; use; use = use->nextUse)
+    {
+        if (use->usedValue != callee)
+            continue;
+        auto annotation = as<IRAnnotation>(use->getUser());
+        if (annotation && annotation->getTarget() == callee)
+            callback(annotation->getInst());
+    }
 }
 
 bool doesCalleeHaveSideEffect(IRInst* callee)


### PR DESCRIPTION
## Summary

- `canAddressesPotentiallyAlias` no longer heap-allocates two `List<IRInst*>` per query; the access chains move to stack-allocated `ShortList<IRInst*, 8>`.
- `forEachAssociatedCallee` walks the callee's use list directly instead of snapshotting it into a `List` first.
- Behaviour-preserving: emitted code is byte-identical, `slang-test` is unchanged.

Complements #13012, which fixes the *other* hot spot in the same pass. Together they address #13010.

## Motivation

#13010 reports that back-end compile time is super-linear in the redundancy-removal pass. #13012 fixes the cubic term — the uncached `doesCalleeHaveSideEffect` query — and that lands the big CUDA and GLSL wins. It does not move Metal at all, which measurement makes plain: on `resource_aggregate` at N=640, `-target metal` is 2072.8 ms before #13012 and 2191.8 ms after.

The reason is that Metal's remaining cost is not the callee query but **memory allocation**. Both scans in `eliminateRedundantLoadStore` run once per (address, scan step) pair, and two helpers they call allocate on every one of those steps:

- `canAddressesPotentiallyAlias` materializes both operands' access chains into `List<IRInst*>` — but only in the `root1 == root2` branch. That branch looks like a corner case and is not: on any target that flattens shader parameters into one aggregate (Metal, and the CPU-like targets) *every* address in the function shares a root, so every query takes it. On SPIR-V and HLSL, which keep parameters as separate globals, it is rarely reached — which is exactly why those targets do not show the problem.
- `forEachAssociatedCallee` reaches the use list through `traverseUsers`, which copies every use into a `List` before iterating.

A sampled profile of `resource_aggregate` at N=640 to Metal, with #13012 applied, is mostly `malloc`, `free` and `__bzero` underneath `getRootAddr`.

## Technical details

**`canAddressesPotentiallyAlias`.** The chains are now collected into `ShortList<IRInst*, 8>`, whose inline buffer covers every access chain depth that occurs in practice (deeper ones still work — they spill to the heap as before). Because a `ShortList` has no `reverse`, and reversing was only ever there to let the comparison loop index root-first, the chains are collected leaf-first and the loop indexes from the end: element `i` counted from the root is `chain[count - 1 - i]`. The comparison order, and therefore which pair the loop decides on, is unchanged.

The walk moved into `_collectAccessChainLeafFirst`, templated on the list type, and the public `getRootAddr(addr, List&, List*)` now calls it and reverses afterwards. That is deliberate: a copy-pasted second walker would be free to drift from the first as access-chain opcodes are added, and this one is already three opcodes wide.

**`forEachAssociatedCallee`.** `traverseUsers` snapshots the use list so a callback can mutate the IR mid-iteration. This callback reads decorations off the annotation's target and mutates nothing, so the snapshot bought nothing and cost an allocation plus a full copy per query. After #13012 the memoizing callers pay that once per callee rather than once per query, but the uncached callers that remain — `slang-ir-simplify-for-emit.cpp` and the autodiff passes — still pay it every time.

**What this does not do.** The scans themselves are still O(n) per load/store, so the pass stays O(n²) and Metal stays super-linear (`resource_aggregate` fits N^1.70). After this change most of what is left on Metal is the scan, split between `tryRemoveRedundantLoad` and `tryRemoveRedundantStore`. Removing that means replacing the scans with a last-clobber/available-value analysis — materially larger and correctness-sensitive, and worth its own change rather than being smuggled in behind an allocation cleanup.

## Results

macOS arm64, Release, `compileInner`, median of 3 after warmup. Baseline column is #13012 applied, so this isolates the change:

| workload | target | #13012 | this PR | |
| --- | --- | ---: | ---: | ---: |
| `resource_aggregate` N=640 | metal | 2191.8 ms | 1548.7 ms | **1.42x** |
| `resource_aggregate` N=320 | metal | 588.1 ms | 426.7 ms | **1.38x** |
| `backend_samplers` N=512 | metal | 358.6 ms | 265.1 ms | **1.35x** |
| `backend_loads` N=640 | metal | 318.2 ms | 252.7 ms | **1.26x** |
| `resource_aggregate` N=640 | glsl | 376.0 ms | 322.4 ms | **1.17x** |
| `backend_matrix` N=512 | cuda | 345.2 ms | 330.8 ms | 1.04x |
| `resource_aggregate` N=640 | spirv | 265.3 ms | 253.6 ms | 1.05x |

SPIR-V and HLSL are flat, as predicted by the mechanism.

Against a clean master baseline (neither PR), the two together take `resource_aggregate` N=640 on Metal from 2072.8 ms to 1548.7 ms, and on CUDA from 10242.8 ms to 521.6 ms.

## Test plan

This is a pure allocation change with no intended behaviour difference, so the test is that nothing moves — there is no new `.slang` case to add, because there is no new behaviour to pin.

- [x] **Emitted code is byte-identical.** Four scaling workloads (`resource_aggregate` N=640, `backend_loads` N=640, `backend_matrix` N=512, `backend_samplers` N=512) compiled to cuda, metal, glsl and spirv — 16 outputs — `diff`-clean between #13012 alone and #13012 + this change.
- [x] **`slang-test -api none -category full`**: 5118/5124, with an identical failure list to the same build without this change — four `slang-unit-test-tool/testServerLoss*` harness tests (the run reports six test-server dispatch failures) and `tests/llvm/enum-bool-switch.slang` / `tests/llvm/printf.slang`, all of which fail the same way on a clean tree on this machine.
- [x] Both the before and after failure lists were captured from actual runs on this machine rather than assumed pre-existing.

Not run locally: Windows and Linux legs, and the GPU-backed categories.

## Suggested reviewers

- **@dshreiner-nv** — already reviewing #13012, the other half of the same pass's cost; these two are best read together.
- **@expipiplus1** — owns the performance initiative (#12941) and authored `slang-ir-redundancy-removal.cpp`, whose scans are the caller that makes these allocation counts matter.
