### PR TITLE
Fix #13028: support motion ray time on OptiX

### DIFF
--- a/prelude/slang-cuda-prelude.h
+++ b/prelude/slang-cuda-prelude.h
@@ -4703,6 +4703,7 @@ __forceinline__ __device__ void optixTrace(
     uint32_t MultiplierForGeometryContributionToHitGroupIndex,
     uint32_t MissShaderIndex,
     RayDesc Ray,
+    float RayTime,
     T* Payload)
 {
     constexpr size_t numRegs = (sizeof(T) + 3) / 4;
@@ -4719,7 +4720,7 @@ __forceinline__ __device__ void optixTrace(
             Ray.Direction,
             Ray.TMin,
             Ray.TMax,
-            0.f, /* Time for motion blur */
+            RayTime,
             InstanceInclusionMask,
             RayFlags,
             RayContributionToHitGroupIndex,
@@ -4742,7 +4743,7 @@ __forceinline__ __device__ void optixTrace(
             Ray.Direction,
             Ray.TMin,
             Ray.TMax,
-            0.f,
+            RayTime,
             InstanceInclusionMask,
             RayFlags,
             RayContributionToHitGroupIndex,
@@ -4753,9 +4754,59 @@ __forceinline__ __device__ void optixTrace(
     }
 }
 
-// Non-template overload for empty payload case.
-// When Slang's type legalization eliminates an empty payload struct,
-// the generated code calls optixTrace without a payload argument.
+// An ordinary TraceRay has no source-level time argument, so preserve its existing behavior by
+// delegating to the time-bearing implementation with time zero. TraceMotionRay selects the overload
+// above, which keeps payload packing identical while forwarding the caller's ray time.
+template<typename T>
+__forceinline__ __device__ void optixTrace(
+    OptixTraversableHandle AccelerationStructure,
+    uint32_t RayFlags,
+    uint32_t InstanceInclusionMask,
+    uint32_t RayContributionToHitGroupIndex,
+    uint32_t MultiplierForGeometryContributionToHitGroupIndex,
+    uint32_t MissShaderIndex,
+    RayDesc Ray,
+    T* Payload)
+{
+    optixTrace(
+        AccelerationStructure,
+        RayFlags,
+        InstanceInclusionMask,
+        RayContributionToHitGroupIndex,
+        MultiplierForGeometryContributionToHitGroupIndex,
+        MissShaderIndex,
+        Ray,
+        0.f,
+        Payload);
+}
+
+// Type legalization removes an empty payload from the generated call. This time-bearing overload
+// ensures that an empty-payload TraceMotionRay still preserves the caller's ray time.
+__forceinline__ __device__ void optixTrace(
+    OptixTraversableHandle AccelerationStructure,
+    uint32_t RayFlags,
+    uint32_t InstanceInclusionMask,
+    uint32_t RayContributionToHitGroupIndex,
+    uint32_t MultiplierForGeometryContributionToHitGroupIndex,
+    uint32_t MissShaderIndex,
+    RayDesc Ray,
+    float RayTime)
+{
+    optixTrace(
+        AccelerationStructure,
+        Ray.Origin,
+        Ray.Direction,
+        Ray.TMin,
+        Ray.TMax,
+        RayTime,
+        InstanceInclusionMask,
+        RayFlags,
+        RayContributionToHitGroupIndex,
+        MultiplierForGeometryContributionToHitGroupIndex,
+        MissShaderIndex);
+}
+
+// Preserve the empty-payload TraceRay ABI by selecting time zero.
 __forceinline__ __device__ void optixTrace(
     OptixTraversableHandle AccelerationStructure,
     uint32_t RayFlags,
@@ -4767,16 +4818,13 @@ __forceinline__ __device__ void optixTrace(
 {
     optixTrace(
         AccelerationStructure,
-        Ray.Origin,
-        Ray.Direction,
-        Ray.TMin,
-        Ray.TMax,
-        0.f,
-        InstanceInclusionMask,
         RayFlags,
+        InstanceInclusionMask,
         RayContributionToHitGroupIndex,
         MultiplierForGeometryContributionToHitGroupIndex,
-        MissShaderIndex);
+        MissShaderIndex,
+        Ray,
+        0.f);
 }
 
 #if (OPTIX_VERSION >= 90000)

--- a/source/slang/hlsl.meta.slang
+++ b/source/slang/hlsl.meta.slang
@@ -20017,7 +20017,7 @@ void __traceMotionRay(
 /// @remarks Extended version of TraceRay with motion blur support
 /// @category raytracing
 [ForceInline]
-[require(glsl_spirv, raytracing_motionblur_raygen_closesthit_miss)]
+[require(cuda_glsl_spirv, raytracing_motionblur_raygen_closesthit_miss)]
 __generic<payload_t>
 void TraceMotionRay(
     RaytracingAccelerationStructure AccelerationStructure,
@@ -20032,6 +20032,7 @@ void TraceMotionRay(
 {
     __target_switch
     {
+    case cuda: __intrinsic_asm "optixTrace";
     case glsl:
     {
         [__vulkanRayPayload]
@@ -20556,17 +20557,18 @@ float4x3 WorldToObject4x3()
 
 /// Returns the current time value for motion blur.
 /// @return Time value between 0 and 1 for motion blur interpolation
-/// @remarks Available when motion blur extension is enabled
+/// @remarks Available when motion blur is enabled
 /// @category raytracing
 __glsl_extension(GL_EXT_ray_tracing)
 __glsl_extension(GL_NV_ray_tracing_motion_blur)
 [NonUniformReturn]
-[require(glsl_spirv, raytracing_motionblur_anyhit_closesthit_intersection_miss)]
+[require(cuda_glsl_spirv, raytracing_motionblur_anyhit_closesthit_intersection_miss)]
 float RayCurrentTime()
 {
     __target_switch
     {
     case glsl:  __intrinsic_asm "(gl_CurrentRayTimeNV)";
+    case cuda: __intrinsic_asm "optixGetRayTime";
     case spirv:
         return spirv_asm
         {

--- a/tests/cuda/optix-motion-ray-time.slang
+++ b/tests/cuda/optix-motion-ray-time.slang
@@ -1,0 +1,82 @@
+//TEST:SIMPLE(filecheck=TRACE): -target cuda -entry rayGen -stage raygeneration
+//TEST:SIMPLE(filecheck=LARGE): -target cuda -entry rayGenLarge -stage raygeneration
+//TEST:SIMPLE(filecheck=EMPTY): -target cuda -entry rayGenEmpty -stage raygeneration
+//TEST:SIMPLE(filecheck=TIME): -target cuda -entry closestHit -stage closesthit
+//TEST:SIMPLE(filecheck=TRACE_PTX): -target ptx -Xnvrtc -I"./external/optix-dev/include/" -entry rayGen -stage raygeneration
+//TEST:SIMPLE(filecheck=LARGE_PTX): -target ptx -Xnvrtc -I"./external/optix-dev/include/" -entry rayGenLarge -stage raygeneration
+//TEST:SIMPLE(filecheck=EMPTY_PTX): -target ptx -Xnvrtc -I"./external/optix-dev/include/" -entry rayGenEmpty -stage raygeneration
+//TEST:SIMPLE(filecheck=TIME_PTX): -target ptx -Xnvrtc -I"./external/optix-dev/include/" -entry closestHit -stage closesthit
+
+// Regression test for https://github.com/shader-slang/slang/issues/13028.
+//
+// OptiX carries motion time into a traced ray and exposes that value to its hit and miss programs.
+// Keep both directions in this test so the source intrinsics cannot drift apart: TraceMotionRay
+// must forward the caller's value, and RayCurrentTime must read the native OptiX ray time. The
+// ray-generation entries cover register-packed, pointer-backed, and legalized-away empty payloads.
+
+// TRACE: optixTrace(
+// TRACE: 0.625
+
+// LARGE: optixTrace(
+// LARGE: 0.75
+
+// EMPTY: optixTrace(
+// EMPTY: 0.25
+
+// TIME: optixGetRayTime()
+
+// TRACE_PTX: mov.f32 {{.*}}, 0f3F200000;
+// TRACE_PTX: _optix_trace_typed
+
+// LARGE_PTX: mov.f32 {{.*}}, 0f3F400000;
+// LARGE_PTX: _optix_trace_typed
+
+// EMPTY_PTX: mov.f32 {{.*}}, 0f3E800000;
+// EMPTY_PTX: _optix_trace_typed
+
+// TIME_PTX: _optix_get_ray_time
+
+RaytracingAccelerationStructure scene;
+
+struct Payload
+{
+    float value;
+};
+
+struct EmptyPayload
+{};
+
+struct LargePayload
+{
+    float values[33];
+};
+
+[shader("raygeneration")]
+void rayGen()
+{
+    RayDesc ray = {float3(0.0), 0.0, float3(0.0, 0.0, 1.0), 100.0};
+    Payload payload = {0.0};
+    TraceMotionRay(scene, RAY_FLAG_NONE, 0xff, 0, 1, 0, ray, 0.625, payload);
+}
+
+[shader("raygeneration")]
+void rayGenLarge()
+{
+    RayDesc ray = {float3(0.0), 0.0, float3(0.0, 0.0, 1.0), 100.0};
+    LargePayload payload = {};
+    TraceMotionRay(scene, RAY_FLAG_NONE, 0xff, 0, 1, 0, ray, 0.75, payload);
+}
+
+[shader("raygeneration")]
+void rayGenEmpty()
+{
+    RayDesc ray = {float3(0.0), 0.0, float3(0.0, 0.0, 1.0), 100.0};
+    EmptyPayload payload;
+    TraceMotionRay(scene, RAY_FLAG_NONE, 0xff, 0, 1, 0, ray, 0.25, payload);
+}
+
+[shader("closesthit")]
+void closestHit(inout Payload payload, BuiltInTriangleIntersectionAttributes attributes)
+{
+    payload.value = RayCurrentTime();
+}


### PR DESCRIPTION
Fixes #13028.

## Motivation

OptiX has a ray-time argument on `optixTrace` and exposes the active value through
`optixGetRayTime()`, but Slang rejected the corresponding existing pipeline API for CUDA:

```slang
TraceMotionRay(scene, flags, mask, sbtOffset, sbtStride, missIndex, ray, 0.625, payload);

[shader("closesthit")]
void closestHit(inout Payload payload, BuiltInTriangleIntersectionAttributes attributes)
{
    payload.value = RayCurrentTime();
}
```

Both entries failed with E36107 because `TraceMotionRay` and `RayCurrentTime` declared only
GLSL/SPIR-V target availability. This is independent of the experimental structural ray-tracing
API and is inconsistent with `HitObject.TraceMotionRay`, which already supports CUDA.

## Proposed solution

Enable the two existing intrinsics for CUDA and map them directly to OptiX's native operations.
`TraceMotionRay` emits an `optixTrace` call that includes the source ray time, while
`RayCurrentTime` emits `optixGetRayTime()`.

The CUDA prelude now uses one time-bearing trace implementation for both payload transport paths.
Ordinary `TraceRay` preserves its existing behavior by delegating with time zero. This keeps the
fix in the intrinsic/prelude layer that already owns the OptiX ABI; no new IR or target-specific
compiler pass is introduced. D3D/NVAPI motion blur remains unsupported.

## Change summary

- Extend the target contracts and CUDA target switches in `hlsl.meta.slang`.
- Forward ray time through both register-packed and pointer-backed OptiX payload transport, with a
  dedicated overload for payloads removed by empty-type legalization.
- Add CUDA-source and NVRTC/PTX tests for register-packed, pointer-backed, and empty payloads, plus
  the `RayCurrentTime` reader.

Verification:

- New focused test: 8/8 passed.
- `tests/cuda`: 97/97 passed, 3 intentionally ignored.
- Related pipeline and motion-time intrinsic tests: 20/20 passed, 1 unsupported test ignored.
- Existing `optix-ser` and SPIR-V `RayCurrentTime` tests passed.

## Concepts and vocabulary

- **Ray time**: the normalized motion-blur time carried by an OptiX ray.
- **Payload transport**: Slang uses OptiX payload registers for values up to 128 bytes and a packed
  pointer for larger values.
- **Empty-payload legalization**: Slang removes an empty payload value from the generated call, so
  the CUDA prelude receives an overload without a payload argument.

## Process report

Consider the `TraceMotionRay` call in the motivating example. The front end resolves it to the
existing core-module intrinsic. Before this change, its `require` target set rejected CUDA before
emission even though the `raytracing_motionblur` capability already includes CUDA. The corrected
intrinsic selects a CUDA target-switch arm and emits the same `optixTrace` wrapper used by
`TraceRay`, with one additional ray-time argument.

The prelude is the source of truth for translating that generated call to native OptiX. Its
existing lower-level `optixTraceWithRegs` already accepted a time, but the public wrapper always
supplied zero. The time-bearing wrapper is now the canonical implementation: it forwards the value
through both the small-payload register path and the large-payload pointer path. The old
time-less wrapper delegates to it with zero, preserving `TraceRay` exactly.

Empty payloads are a valid, intentional input shape rather than a malformed IR spelling. Existing
type legalization removes such a payload and already relied on a no-payload prelude overload. A
parallel time-bearing no-payload overload therefore handles that established shape at the ABI
boundary instead of adding a special case to legalization or emission. The regression instantiates
all three valid shapes and compiles them through NVRTC.

For `RayCurrentTime`, the same front-end availability mismatch existed. Its CUDA arm maps directly
to `optixGetRayTime`; there is no synthesized state and no attempt to recover the time after a
trace. The PTX check confirms the native `_optix_get_ray_time` operation is emitted.
