### PR TITLE
Allow forward references between generic constraints

### DIFF
--- a/source/slang/slang-check-constraint.cpp
+++ b/source/slang/slang-check-constraint.cpp
@@ -975,21 +975,6 @@ static bool isDeferredValidationWitness(Val* witness)
            as<ConcreteVariadicPackCountWitness>(witness) || as<DiffTypeInfoWitness>(witness);
 }
 
-// Return the outermost generic declaration in a nested generic declaration
-// chain.
-GenericDecl* getOutermostGenericDecl(GenericDecl* genericDecl)
-{
-    if (!genericDecl)
-        return nullptr;
-
-    for (auto parentGenericDecl = as<GenericDecl>(genericDecl->parentDecl); parentGenericDecl;
-         parentGenericDecl = as<GenericDecl>(parentGenericDecl->parentDecl))
-    {
-        genericDecl = parentGenericDecl;
-    }
-    return genericDecl;
-}
-
 // Owns one generic-application solve. The class collects ordinary constraints,
 // default generic arguments, and witness constraints into solver constraints,
 // runs the work-list loop, and stores the current argument arrays used to build
@@ -3424,10 +3409,7 @@ DeclRef<Decl> SemanticsVisitor::trySolveGenericArguments(
     if (providedOrdinaryArgs.getCount() != 0)
     {
         auto genericDecl = genericDeclRef.getDecl();
-        auto outermostGenericDecl = getOutermostGenericDecl(genericDecl);
-        SLANG_ASSERT(outermostGenericDecl == genericDecl);
-
-        if (!solver.setProvidedArg(outermostGenericDecl, providedOrdinaryArgs))
+        if (!solver.setProvidedArg(genericDecl, providedOrdinaryArgs))
             return DeclRef<Decl>();
     }
 

--- a/source/slang/slang-check-overload.cpp
+++ b/source/slang/slang-check-overload.cpp
@@ -1185,16 +1185,6 @@ bool SemanticsVisitor::TryCheckOverloadCandidateConstraints(
     auto substArgs = tryGetGenericArguments(candidate.subst, genericDeclRef.getDecl());
     SLANG_ASSERT(substArgs.getCount());
 
-    bool genericIsOutermost = true;
-    for (auto p = genericDeclRef.getDecl()->parentDecl; p; p = p->parentDecl)
-    {
-        if (as<GenericDecl>(p))
-        {
-            genericIsOutermost = false;
-            break;
-        }
-    }
-
     Index explicitCount = candidate.explicitGenericArgCount;
     if (explicitCount < 0 || explicitCount > substArgs.getCount())
         explicitCount = substArgs.getCount();
@@ -1217,41 +1207,36 @@ bool SemanticsVisitor::TryCheckOverloadCandidateConstraints(
     //
     // On solver failure we fall through to the per-constraint loop, which
     // re-derives the failing constraint to emit a precise diagnostic (the solver
-    // reports none). The solver's `setProvidedArg` requires an outermost generic
-    // when ordinary arguments are provided, so a nested generic application keeps
-    // the linear pass for now.
-    if (genericIsOutermost)
+    // reports none). The provided arguments belong to `genericDeclRef` itself;
+    // any enclosing generic substitutions are already carried by that decl-ref.
+    ShortList<Val*> providedOrdinaryArgs;
+    for (Index i = 0; i < explicitCount; i++)
+        providedOrdinaryArgs.add(substArgs[i]);
+
+    GenericInferenceContext inferenceContext;
+    inferenceContext.genericDecl = genericDeclRef.getDecl();
+
+    ConversionCost solveCost = kConversionCost_None;
+    auto solved = trySolveGenericArguments(
+        _Move(inferenceContext),
+        genericDeclRef,
+        providedOrdinaryArgs.getArrayView().arrayView,
+        solveCost);
+    if (solved)
     {
-        ShortList<Val*> providedOrdinaryArgs;
-        for (Index i = 0; i < explicitCount; i++)
-            providedOrdinaryArgs.add(substArgs[i]);
-
-        GenericInferenceContext inferenceContext;
-        inferenceContext.genericDecl = genericDeclRef.getDecl();
-
-        ConversionCost solveCost = kConversionCost_None;
-        auto solved = trySolveGenericArguments(
-            _Move(inferenceContext),
-            genericDeclRef,
-            providedOrdinaryArgs.getArrayView().arrayView,
-            solveCost);
-        if (solved)
-        {
-            auto solvedArgs =
-                tryGetGenericArguments(SubstitutionSet(solved), genericDeclRef.getDecl());
-            candidate.subst =
-                SubstitutionSet(m_astBuilder->getGenericAppDeclRef(genericDeclRef, solvedArgs));
-            // Note: deliberately do not fold `solveCost` into `conversionCostSum`
-            // here. The previous per-constraint validation added no conformance
-            // cost at this stage, and doing so shifts overload ranking (e.g.
-            // breaks ties that should stay ambiguous).
-            return true;
-        }
-        // Solver failed: in real mode fall through so the per-constraint loop can
-        // emit a precise diagnostic; in just-trying mode reject the candidate.
-        if (context.mode == OverloadResolveContext::Mode::JustTrying)
-            return false;
+        auto solvedArgs = tryGetGenericArguments(SubstitutionSet(solved), genericDeclRef.getDecl());
+        candidate.subst =
+            SubstitutionSet(m_astBuilder->getGenericAppDeclRef(genericDeclRef, solvedArgs));
+        // Note: deliberately do not fold `solveCost` into `conversionCostSum`
+        // here. The previous per-constraint validation added no conformance
+        // cost at this stage, and doing so shifts overload ranking (e.g.
+        // breaks ties that should stay ambiguous).
+        return true;
     }
+    // Solver failed: in real mode fall through so the per-constraint loop can
+    // emit a precise diagnostic; in just-trying mode reject the candidate.
+    if (context.mode == OverloadResolveContext::Mode::JustTrying)
+        return false;
 
     ShortList<Val*> newArgs;
     for (auto arg : substArgs)

--- a/source/slang/slang-lower-to-ir.cpp
+++ b/source/slang/slang-lower-to-ir.cpp
@@ -13068,139 +13068,103 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         return Slang::maybeGetConstExprType(getBuilder(), type, decl);
     }
 
-    /// Emit appropriate generic parameters for a constraint, and return the value of that
-    /// constraint.
+    /// Creates a hidden generic parameter and makes it visible before its type is lowered.
     ///
-    /// The `supType` paramete represents the super-type that a parameter is constrained to.
-    IRInst* emitGenericConstraintValue(
-        IRGenContext* subContext,
-        DeclRef<GenericTypeConstraintDecl> constraintDeclRef,
-        IRType* supType)
+    /// The null type is temporary: `emitGenericDecl` completes every placeholder before it emits
+    /// the generic body or returns the generic. IR parameter cloning uses the same two-pass form
+    /// because parameter types may refer to parameters declared later in the block.
+    void predeclareGenericConstraintDecl(IRGenContext* subContext, Decl* constraintDecl)
     {
-        auto constraintDecl = constraintDeclRef.getDecl();
-
-        auto subBuilder = subContext->irBuilder;
-
-        // There are two cases we care about here.
-        //
-        if (auto andType = as<IRConjunctionType>(supType))
-        {
-            // The non-trivial case is when the constraint on a generic parameter
-            // was of the form `T : A & B`. In this case, we really want to
-            // emit the function with parameters for each of the two independent
-            // constraints `T : A` and `T : B`.
-            //
-            // We will loop over the "cases" of the conjunction (since
-            // the `IRConunctionType` can support more than just binary
-            // conjunctions) and recursively add constraints for each.
-            //
-            List<IRInst*> caseVals;
-            auto caseCount = andType->getCaseCount();
-            for (Int i = 0; i < caseCount; ++i)
-            {
-                auto caseType = andType->getCaseType(i);
-                auto caseVal = emitGenericConstraintValue(subContext, constraintDecl, caseType);
-                caseVals.add(caseVal);
-            }
-
-            return subBuilder->emitMakeTuple(caseVals);
-        }
-        else
-        {
-            // The case case is any other type being used as the constraint.
-            //
-            // The constraint will then map to a single generic parameter passing
-            // a witness table for conformance to the given `supType`.
-            //
-            auto param = subBuilder->emitParam(subBuilder->getWitnessTableType(supType));
-            addNameHint(context, param, constraintDecl);
-
-            // In order to support some of the "any-value" work in dynamic dispatch
-            // we have to attach the interface that was used as a constraint onto the
-            // type that is being constrained (which we expect to be a generic type
-            // parameter).
-            //
-            // TODO: It feels a bit gross to be doing this here; perhaps the front-end
-            // should handle propgation of value-size information from constraints
-            // back to generic parameters?
-            //
-            if (auto genParamDeclRef = isDeclRefTypeOf<GenericTypeParamDeclBase>(
-                    getSub(subContext->astBuilder, constraintDeclRef)))
-            {
-                auto typeParamDeclVal = subContext->findLoweredDecl(genParamDeclRef.getDecl());
-                SLANG_ASSERT(typeParamDeclVal && typeParamDeclVal->val);
-                subBuilder->addTypeConstraintDecoration(typeParamDeclVal->val, supType);
-            }
-
-            return param;
-        }
+        auto param = subContext->irBuilder->emitParam(nullptr);
+        addNameHint(context, param, constraintDecl);
+        subContext->setValue(constraintDecl, LoweredValInfo::simple(param));
     }
 
-    void emitGenericConstraintDecl(
+    /// Returns the placeholder created for a checked generic constraint.
+    IRParam* getPredeclaredGenericConstraintParam(IRGenContext* subContext, Decl* constraintDecl)
+    {
+        auto value = subContext->findLoweredDecl(constraintDecl);
+        SLANG_RELEASE_ASSERT(value && value->val);
+        auto param = as<IRParam>(value->val);
+        SLANG_RELEASE_ASSERT(param);
+        return param;
+    }
+
+    void completeGenericConstraintDecl(
         IRGenContext* subContext,
         DeclRef<GenericTypeConstraintDecl> constraintDeclRef)
     {
         auto supType = lowerType(subContext, getSup(subContext->astBuilder, constraintDeclRef));
-        auto value = emitGenericConstraintValue(subContext, constraintDeclRef, supType);
-        subContext->setValue(constraintDeclRef.getDecl(), LoweredValInfo::simple(value));
+        // `SemanticsDeclHeaderVisitor::visitGenericTypeConstraintDecl` recursively splits every
+        // valid `T : A & B` constraint into one declaration per leaf. Equality constraints are not
+        // split, but their two operands must both be proper constrainee types and therefore cannot
+        // be conjunctions. Thus each checked constraint maps to exactly one hidden IR parameter.
+        SLANG_RELEASE_ASSERT(!as<IRConjunctionType>(supType));
+        auto constraintDecl = constraintDeclRef.getDecl();
+        auto param = getPredeclaredGenericConstraintParam(subContext, constraintDecl);
+        param->setFullType(subContext->irBuilder->getWitnessTableType(supType));
+
+        // In order to support some of the "any-value" work in dynamic dispatch, attach the
+        // interface used as a constraint to the constrained generic type parameter.
+        //
+        // TODO: The front end should probably propagate value-size information from constraints
+        // back to generic parameters instead of having IR lowering do it here.
+        if (auto genParamDeclRef = isDeclRefTypeOf<GenericTypeParamDeclBase>(
+                getSub(subContext->astBuilder, constraintDeclRef)))
+        {
+            auto typeParamDeclVal = subContext->findLoweredDecl(genParamDeclRef.getDecl());
+            SLANG_ASSERT(typeParamDeclVal && typeParamDeclVal->val);
+            subContext->irBuilder->addTypeConstraintDecoration(typeParamDeclVal->val, supType);
+        }
     }
 
-    void emitGenericConstraintDecl(
+    void completeGenericConstraintDecl(
         IRGenContext* subContext,
         DeclRef<TypeCoercionConstraintDecl> constraintDeclRef)
     {
         auto constraintDecl = constraintDeclRef.getDecl();
-        auto subBuilder = subContext->irBuilder;
         auto fromType =
             lowerType(subContext, getFromType(subContext->astBuilder, constraintDeclRef));
         auto toType = lowerType(subContext, getToType(subContext->astBuilder, constraintDeclRef));
-        auto funcType = subBuilder->getFuncType(1, &fromType, toType);
-        auto param = subBuilder->emitParam(funcType);
-        addNameHint(context, param, constraintDecl);
-        subContext->setValue(constraintDecl, LoweredValInfo::simple(param));
+        auto param = getPredeclaredGenericConstraintParam(subContext, constraintDecl);
+        param->setFullType(subContext->irBuilder->getFuncType(1, &fromType, toType));
     }
 
-    void emitGenericConstraintDecl(
+    void completeGenericConstraintDecl(
         IRGenContext* subContext,
         DeclRef<NonEmptyPackConstraintDecl> constraintDeclRef)
     {
         auto constraintDecl = constraintDeclRef.getDecl();
+        auto param = getPredeclaredGenericConstraintParam(subContext, constraintDecl);
         auto subBuilder = subContext->irBuilder;
-        auto witnessType = subBuilder->getWitnessTableType(subBuilder->getVoidType());
-        auto param = subBuilder->emitParam(witnessType);
-        addNameHint(context, param, constraintDecl);
-        subContext->setValue(constraintDecl, LoweredValInfo::simple(param));
+        param->setFullType(subBuilder->getWitnessTableType(subBuilder->getVoidType()));
     }
 
-    void emitGenericConstraintDecl(
+    void completeGenericConstraintDecl(
         IRGenContext* subContext,
         DeclRef<GenericVariadicPackCountConstraintDecl> constraintDeclRef)
     {
         auto constraintDecl = constraintDeclRef.getDecl();
-        auto subBuilder = subContext->irBuilder;
         // Generic lowering turns each source generic constraint into a hidden
         // parameter. The checker has already validated `countof(Pack) == Count`,
         // so lowering only needs a proof value with the same witness-table
         // representation consumed by `visitDeclaredVariadicPackCountWitness`.
-        auto witnessType = subBuilder->getWitnessTableType(subBuilder->getVoidType());
-        auto param = subBuilder->emitParam(witnessType);
-        addNameHint(context, param, constraintDecl);
-        subContext->setValue(constraintDecl, LoweredValInfo::simple(param));
+        auto param = getPredeclaredGenericConstraintParam(subContext, constraintDecl);
+        auto subBuilder = subContext->irBuilder;
+        param->setFullType(subBuilder->getWitnessTableType(subBuilder->getVoidType()));
     }
 
-    void emitGenericConstraintDecl(
+    void completeGenericConstraintDecl(
         IRGenContext* subContext,
         DeclRef<HasDiffTypeInfoConstraintDecl> constraintDeclRef)
     {
         auto constraintDecl = constraintDeclRef.getDecl();
-        auto subBuilder = subContext->irBuilder;
-        auto param = subBuilder->emitParam(subBuilder->getVoidType());
-        addNameHint(context, param, constraintDecl);
-        subContext->setValue(constraintDecl, LoweredValInfo::simple(param));
+        auto param = getPredeclaredGenericConstraintParam(subContext, constraintDecl);
+        param->setFullType(subContext->irBuilder->getVoidType());
     }
 
     template<typename T>
-    void emitGenericConstraintDecl(
+    void completeGenericConstraintDecl(
         IRGenContext* subContext,
         DeclRef<GenericDecl> genericDeclRef,
         T* constraintDecl)
@@ -13208,7 +13172,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
         auto constraintDeclRef =
             subContext->astBuilder->getMemberDeclRef(genericDeclRef, constraintDecl)
                 .template as<T>();
-        emitGenericConstraintDecl(subContext, constraintDeclRef);
+        completeGenericConstraintDecl(subContext, constraintDeclRef);
     }
 
     IRGeneric* emitGenericDecl(IRGenContext* subContext, DeclRef<GenericDecl> genericDeclRef)
@@ -13260,14 +13224,29 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 subContext->setValue(valDecl, LoweredValInfo::simple(param));
             }
         }
-        // Then we emit constraint parameters, again in
-        // declaration order.
+        // Consider this example:
+        //
+        //     void use<Element, Storage>()
+        //         where Storage : IStorage<Element>
+        //         where Element : __BuiltinFloatingPointType;
+        //
+        // Lowering `IStorage<Element>` consumes the witness for the later `Element` constraint.
+        // Declare every hidden parameter in source order first so that the complete checked
+        // constraint environment is available when the next pass lowers parameter types.
+        for (auto constraintDecl : genericDecl->getDirectMemberDecls())
+        {
+            if (isGenericConstraintParameterDecl(constraintDecl))
+                predeclareGenericConstraintDecl(subContext, constraintDecl);
+        }
+
+        // Now that every constraint has an IR value, lower the parameter types in declaration
+        // order. IR parameters intentionally permit forward references in their types.
         for (auto constraintDecl : genericDecl->getDirectMemberDecls())
         {
             if (auto genericTypeConstraintDecl = as<GenericTypeConstraintDecl>(constraintDecl))
             {
                 if (isGenericConstraintParameterDecl(genericTypeConstraintDecl))
-                    emitGenericConstraintDecl(
+                    completeGenericConstraintDecl(
                         subContext,
                         genericDeclRef,
                         genericTypeConstraintDecl);
@@ -13276,7 +13255,7 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
                 auto typeCoercionConstraintDecl = as<TypeCoercionConstraintDecl>(constraintDecl))
             {
                 if (isGenericConstraintParameterDecl(typeCoercionConstraintDecl))
-                    emitGenericConstraintDecl(
+                    completeGenericConstraintDecl(
                         subContext,
                         genericDeclRef,
                         typeCoercionConstraintDecl);
@@ -13284,21 +13263,27 @@ struct DeclLoweringVisitor : DeclVisitor<DeclLoweringVisitor, LoweredValInfo>
             else if (auto nonEmptyConstraintDecl = as<NonEmptyPackConstraintDecl>(constraintDecl))
             {
                 if (isGenericConstraintParameterDecl(nonEmptyConstraintDecl))
-                    emitGenericConstraintDecl(subContext, genericDeclRef, nonEmptyConstraintDecl);
+                    completeGenericConstraintDecl(
+                        subContext,
+                        genericDeclRef,
+                        nonEmptyConstraintDecl);
             }
             else if (
                 auto packCountConstraintDecl =
                     as<GenericVariadicPackCountConstraintDecl>(constraintDecl))
             {
                 if (isGenericConstraintParameterDecl(packCountConstraintDecl))
-                    emitGenericConstraintDecl(subContext, genericDeclRef, packCountConstraintDecl);
+                    completeGenericConstraintDecl(
+                        subContext,
+                        genericDeclRef,
+                        packCountConstraintDecl);
             }
             else if (
                 auto hasDiffTypeInfoConstraintDecl =
                     as<HasDiffTypeInfoConstraintDecl>(constraintDecl))
             {
                 if (isGenericConstraintParameterDecl(hasDiffTypeInfoConstraintDecl))
-                    emitGenericConstraintDecl(
+                    completeGenericConstraintDecl(
                         subContext,
                         genericDeclRef,
                         hasDiffTypeInfoConstraintDecl);

--- a/tests/language-feature/generics/generic-associated-equality-constraint-dependency-order.slang
+++ b/tests/language-feature/generics/generic-associated-equality-constraint-dependency-order.slang
@@ -1,0 +1,48 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+interface IContext
+{
+    associatedtype TraceContext;
+}
+
+interface ISchema
+{
+    associatedtype TraceContext;
+}
+
+struct TraceContext
+{}
+
+struct Context : IContext
+{
+    typealias TraceContext = ::TraceContext;
+}
+
+struct Schema : ISchema
+{
+    typealias TraceContext = ::TraceContext;
+}
+
+struct Tracer<S>
+    where S : ISchema
+{}
+
+extension<S> Tracer<S>
+    where S : ISchema
+{
+    // The equality requirement needs the later IContext witness before
+    // `Actual.TraceContext` can be resolved. Because this method is nested in a
+    // generic extension, its solver must also preserve the enclosing value of S.
+    int useContext<Actual>()
+        where Actual.TraceContext == S.TraceContext
+        where Actual : IContext
+    {
+        return 23;
+    }
+}
+
+void main()
+{
+    printf("%d\n", Tracer<Schema>().useContext<Context>());
+    // CHECK: 23
+}

--- a/tests/language-feature/generics/generic-coercion-constraint-dependency-order.slang
+++ b/tests/language-feature/generics/generic-coercion-constraint-dependency-order.slang
@@ -1,0 +1,38 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+interface IContext
+{
+    associatedtype Element;
+}
+
+struct MyFloat
+{
+    float value;
+
+    __implicit_conversion(100)
+    __init(int value)
+    {
+        this.value = float(value);
+    }
+}
+
+struct Context : IContext
+{
+    typealias Element = MyFloat;
+}
+
+// Lowering the coercion-witness parameter type needs `T.Element`. The witness that opens that
+// associated type is deliberately declared by the later `T : IContext` constraint.
+int useElement<T>(T.Element value)
+    where T.Element(int) implicit
+    where T : IContext
+{
+    return 17;
+}
+
+void main()
+{
+    MyFloat value = MyFloat(1);
+    printf("%d\n", useElement<Context>(value));
+    // CHECK: 17
+}

--- a/tests/language-feature/generics/generic-conjunction-constraint-dependency-order.slang
+++ b/tests/language-feature/generics/generic-conjunction-constraint-dependency-order.slang
@@ -1,0 +1,47 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+interface IStorage<Element>
+    where Element : __BuiltinFloatingPointType
+{
+    Element load();
+}
+
+interface IMarker
+{
+    int marker();
+}
+
+struct CombinedStorage : IStorage<float>, IMarker
+{
+    float load()
+    {
+        return 1.0;
+    }
+
+    int marker()
+    {
+        return 2;
+    }
+}
+
+Element loadCombined<Element, Storage>(Storage storage)
+    where Storage : IStorage<Element> & IMarker
+    where Element : __BuiltinFloatingPointType
+{
+    return storage.load() + Element(storage.marker());
+}
+
+// Calling between opposite source orders checks that each flattened conjunction witness remains
+// paired with its source-order parameter when the generic is specialized.
+Element forwardCombined<Element, Storage>(Storage storage)
+    where Element : __BuiltinFloatingPointType
+    where Storage : IStorage<Element> & IMarker
+{
+    return loadCombined<Element, Storage>(storage);
+}
+
+void main()
+{
+    printf("%d\n", int(forwardCombined<float, CombinedStorage>(CombinedStorage())));
+    // CHECK: 3
+}

--- a/tests/language-feature/generics/generic-constraint-dependency-chain.slang
+++ b/tests/language-feature/generics/generic-constraint-dependency-chain.slang
@@ -1,0 +1,47 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+// Each constraint below needs a witness declared later in the source. This exercises more than a
+// single forward reference: IR lowering must predeclare the complete constraint environment before
+// it assigns parameter types for `loadHolder`.
+interface IStorage<Element>
+    where Element : __BuiltinFloatingPointType
+{
+    Element load();
+}
+
+interface IHolder<Element, Storage>
+    where Storage : IStorage<Element>
+    where Element : __BuiltinFloatingPointType
+{
+    Element load();
+}
+
+struct FloatStorage : IStorage<float>
+{
+    float load()
+    {
+        return 13.0;
+    }
+}
+
+struct FloatHolder : IHolder<float, FloatStorage>
+{
+    float load()
+    {
+        return 13.0;
+    }
+}
+
+Element loadHolder<Element, Storage, Holder>(Holder holder)
+    where Holder : IHolder<Element, Storage>
+    where Storage : IStorage<Element>
+    where Element : __BuiltinFloatingPointType
+{
+    return holder.load();
+}
+
+void main()
+{
+    printf("%d\n", int(loadHolder<float, FloatStorage, FloatHolder>(FloatHolder())));
+    // CHECK: 13
+}

--- a/tests/language-feature/generics/generic-constraint-order-independent.slang
+++ b/tests/language-feature/generics/generic-constraint-order-independent.slang
@@ -1,0 +1,39 @@
+//TEST:INTERPRET(filecheck=CHECK):
+
+// A generic constraint may depend on another constraint declared later in the source. IR lowering
+// must represent the complete checked constraint set instead of depending on source order.
+interface IStorage<Element>
+    where Element : __BuiltinFloatingPointType
+{
+    Element load();
+}
+
+struct FloatStorage : IStorage<float>
+{
+    float load()
+    {
+        return 12.0;
+    }
+}
+
+Element loadStorage<Element, Storage>(Storage storage)
+    where Storage : IStorage<Element>
+    where Element : __BuiltinFloatingPointType
+{
+    return storage.load();
+}
+
+// The caller deliberately declares the same constraints in the opposite order. Each generic keeps
+// its own source-order signature, so specializing `loadStorage` must preserve its argument roles.
+Element forwardLoad<Element, Storage>(Storage storage)
+    where Element : __BuiltinFloatingPointType
+    where Storage : IStorage<Element>
+{
+    return loadStorage<Element, Storage>(storage);
+}
+
+void main()
+{
+    printf("%d\n", int(forwardLoad<float, FloatStorage>(FloatStorage())));
+    // CHECK: 12
+}


### PR DESCRIPTION
## Motivation

Consider a generic whose first constraint uses evidence declared by a later constraint:

```slang
interface IContext { associatedtype TraceContext; }

extension<S> Tracer<S> where S : ISchema
{
    void trace<Actual>()
        where Actual.TraceContext == S.TraceContext
        where Actual : IContext;
}
```

This declaration is valid: the complete constraint set proves that `Actual.TraceContext` exists. Constraint processing nevertheless depended on source order in two places. Outermost generics reached the fixed-point solver but IR lowering could ask for a later hidden witness before it existed. Nested generic methods bypassed the solver entirely and rejected the associated-type equality before considering the later conformance. This is #9334.

## Proposed solution

Use the existing fixed-point generic solver for nested and outermost generic applications alike. Explicit arguments are installed on the generic being applied, while its declaration reference continues to carry any enclosing generic substitutions.

Then build hidden generic-constraint IR parameters in two contiguous passes. The first pass creates every parameter in source order and records it in the existing declaration-to-IR environment. The second pass lowers and assigns each checked parameter type, again in source order.

Together these changes make constraint checking independent of declaration order without changing the generic ABI, walking arbitrary `Val` graphs, or permuting specialization operands.

## Change summary

- Run fixed-point constraint solving for nested generic overload candidates.
- Install provided ordinary arguments on the generic declaration they belong to.
- Predeclare all hidden generic-constraint IR parameters before lowering their types.
- Complete generic type, coercion, pack, pack-count, and differentiation constraint parameter types in a second pass.
- Add regressions for a direct dependency, a dependency chain, opposite caller/callee orders, conjunction flattening, coercion, and an associated-type equality on a generic method inside a generic extension.

## Concepts and vocabulary

- **Hidden constraint parameter**: the IR generic parameter that carries proof of a checked source constraint.
- **Constraint environment**: the existing declaration-to-lowered-value mapping used while lowering dependent types and witnesses.
- **Enclosing substitution**: the already-specialized outer generic arguments carried by a nested generic method's declaration reference.
- **Conjunction flattening**: the front-end normalization that turns `T : A & B` into separate checked constraints before IR generation.

## Process report

Consider the nested `trace<Actual>` example above. `TryCheckOverloadCandidateConstraints` previously sent only outermost generics to `trySolveGenericArguments`; nested methods fell through to a one-pass loop over source constraints. That loop tried the equality first, before it had appended the `Actual : IContext` witness needed to resolve the associated type. The generic solver already owns dependency scheduling, and the nested method's `DeclRef` already carries `S`, so the principled fix is to use that solver and install the explicit `Actual` argument on the method's own `GenericDecl`. No new representation or fallback is introduced.

For IR generation, `SemanticsDeclHeaderVisitor::visitGenericTypeConstraintDecl` has already checked the complete source constraint set and flattened conjunctions into individual declarations. A dependency on a later declaration is therefore an intentional semantic shape. Previously, `DeclLoweringVisitor::emitGenericDecl` created a hidden parameter only after lowering that constraint's type. Lowering a type such as `IStorage<Element>` can need the later `Element` witness and ask `IRGenContext::findLoweredDecl` for it before it exists, eventually reaching the internal-error path in `visitGenericTypeConstraintDecl`.

The IR fix changes that producer boundary. `predeclareGenericConstraintDecl` creates and registers every hidden parameter first; `completeGenericConstraintDecl` assigns its checked witness or function type after the whole environment exists. No generic body or IR pass runs between the loops, and every placeholder is completed before `emitGenericDecl` returns. The existing source-order parameter and specialization-operand representation remains the single ABI source of truth.

The five focused interpreter tests pass, and the new nested test also compiles to HLSL with `-validate-ir`. A capped run of `tests/language-feature/generics` passes 270/270 tests (61 ignored).

Fixes #9334.
